### PR TITLE
DATA_SCIENCE_UC00196_Fire_Hydrant_Analysis_for_sprint_1

### DIFF
--- a/Playground/HanwenDun/UC00196_Fire_Hydrant_Coverage_Analysis.ipynb
+++ b/Playground/HanwenDun/UC00196_Fire_Hydrant_Coverage_Analysis.ipynb
@@ -5,7 +5,7 @@
    "id": "e43ca633-4869-47c7-bc24-5e962bb69d8a",
    "metadata": {},
    "source": [
-    "# Melbourne Fire Hydrant Geographic Data Visualization Analysis Project"
+    "# Melbourne Fire Hydrant Geographic Data visualisation Analysis Project"
    ]
   },
   {
@@ -39,7 +39,7 @@
    "id": "2bdf9084-6e0e-4483-8759-ee3568530ac1",
    "metadata": {},
    "source": [
-    "The goal of this use case is to analyze the spatial distribution and infrastructure of fire hydrants within a city using a real-world dataset. This involves examining hydrant types, identifying the most common street segments with hydrants, and visualizing their geographical locations on an interactive map. The analysis can assist with urban planning, fire safety infrastructure optimization, and resource deployment strategies."
+    "The goal of this use case is to analyse the spatial distribution and infrastructure of fire hydrants within a city using a real-world dataset. This involves examining hydrant types, identifying the most common street segments with hydrants, and visualizing their geographical locations on an interactive map. The analysis can assist with urban planning, fire safety infrastructure optimisation, and resource deployment strategies."
    ]
   },
   {
@@ -63,7 +63,7 @@
     "\n",
     "3. Are there areas with potential data inconsistencies (e.g., missing street names)?  \n",
     "\n",
-    "4. How can this data be visualized on a map to aid infrastructure planning?  \n",
+    "4. How can this data be visualised on a map to aid infrastructure planning?  \n",
     "\n",
     "By combining data cleaning, geospatial plotting, and categorical analysis, this assessment helps generate insights that can guide maintenance operations, urban fire response strategies, and infrastructure auditing.  "
    ]
@@ -204,7 +204,7 @@
    "id": "408d08c2-4aa6-4b7c-ae26-d28f1037da6c",
    "metadata": {},
    "source": [
-    "This dataset provides detailed information about Melbourne's fire hydrant assets, including each hydrant's ID, geographic description, maintenance unit, equipment type, street location, and latitude and longitude coordinates. These fields enable in-depth analysis of the hydrants' geographic distribution, type composition, and relationship to roads. Some fields contain missing values and require further cleaning. This dataset can be used for analysis scenarios such as geographic visualization, infrastructure management, and assessing a city's emergency response capabilities."
+    "This dataset provides detailed information about Melbourne's fire hydrant assets, including each hydrant's ID, geographic description, maintenance unit, equipment type, street location, and latitude and longitude coordinates. These fields enable in-depth analysis of the hydrants' geographic distribution, type composition, and relationship to roads. Some fields contain missing values and require further cleaning. This dataset can be used for analysis scenarios such as geographic visualisation, infrastructure management, and assessing a city's emergency response capabilities."
    ]
   },
   {
@@ -246,7 +246,7 @@
    "id": "fa152f97-b57e-4d2e-b9da-0d2a6d189203",
    "metadata": {},
    "source": [
-    "This information shows the basic structure and data quality of the fire hydrant dataset, comprising 307 records and 10 fields. These fields include asset number, description, maintenance unit, type information, and geographic location. While most fields have no missing values, the marker_type_lupvalue and site_lupvalue fields are completely missing, and the street_segment_lupvalue field is partially missing (having only 284 non-null values). This information is valuable for subsequent data cleaning, visualization, and analysis."
+    "This information shows the basic structure and data quality of the fire hydrant dataset, comprising 307 records and 10 fields. These fields include asset number, description, maintenance unit, type information, and geographic location. While most fields have no missing values, the marker_type_lupvalue and site_lupvalue fields are completely missing, and the street_segment_lupvalue field is partially missing (having only 284 non-null values). This information is valuable for subsequent data cleaning, visualisation, and analysis."
    ]
   },
   {
@@ -12136,7 +12136,7 @@
    "id": "e4fd6a86-eeef-43f5-a45f-f5fbd2cd09b4",
    "metadata": {},
    "source": [
-    "I used the geocoding tool Nominatim to automatically fill in missing street information (street_segment_lupvalue) in the fire hydrant dataset and removed any completely empty columns. We then created an interactive visualization using folium, plotting all fire hydrants with street information on a map of Melbourne by their latitude and longitude, displaying the asset description and street name on each marker. This process improved data integrity and provided a visual representation of the geographic distribution of fire hydrants, facilitating subsequent analysis and decision-making regarding urban infrastructure layout."
+    "I used the geocoding tool Nominatim to automatically fill in missing street information (street_segment_lupvalue) in the fire hydrant dataset and removed any completely empty columns. We then created an interactive visualisation using folium, plotting all fire hydrants with street information on a map of Melbourne by their latitude and longitude, displaying the asset description and street name on each marker. This process improved data integrity and provided a visual representation of the geographic distribution of fire hydrants, facilitating subsequent analysis and decision-making regarding urban infrastructure layout."
    ]
   },
   {
@@ -12182,7 +12182,7 @@
    "id": "6cf2f237-cb17-44ca-aaf8-58845fc596a3",
    "metadata": {},
    "source": [
-    "The latest test results show that all missing values in the street_segment_lupvalue field have been successfully imputed, and the entire dataset currently contains no missing items. The missing value statistics for all fields are 0, indicating that the data has been completely cleaned, laying a solid foundation for subsequent geographic analysis and visualization."
+    "The latest test results show that all missing values in the street_segment_lupvalue field have been successfully imputed, and the entire dataset currently contains no missing items. The missing value statistics for all fields are 0, indicating that the data has been completely cleaned, laying a solid foundation for subsequent geographic analysis and visualisation."
    ]
   },
   {
@@ -12190,7 +12190,7 @@
    "id": "ac77e744-969e-440e-855a-729561a4e7fc",
    "metadata": {},
    "source": [
-    "## Fire hydrant data visualization analysis"
+    "## Fire hydrant data visualisation analysis"
    ]
   },
   {
@@ -12334,7 +12334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": null,
    "id": "5c7769e6-ff75-49da-ad2b-95e014a7516f",
    "metadata": {},
    "outputs": [
@@ -12414,7 +12414,7 @@
    "id": "aa578752-f884-4858-bdac-040728b75a6e",
    "metadata": {},
    "source": [
-    "The kernel density estimation curve further reveals the distribution trends of fire hydrants at different longitudes. As can be seen, the KDE curve forms a significant peak near 144.96, corresponding to the highest number of fire hydrants in the histogram, indicating a hotspot. Conversely, the curve dips near 144.94, corresponding to the CityLink Expressway section, confirming the relatively limited infrastructure coverage in this area. Furthermore, the KDE curve flattens at its extremes (144.91 and 144.99), indicating that the number of fire hydrants in these marginal areas is sparsely distributed and exhibits little variation. The KDE curve provides a visual understanding of the locations where firefighting facilities are concentrated, facilitating the scheduling and optimized layout of urban firefighting resources."
+    "The kernel density estimation curve further reveals the distribution trends of fire hydrants at different longitudes. As can be seen, the KDE curve forms a significant peak near 144.96, corresponding to the highest number of fire hydrants in the histogram, indicating a hotspot. Conversely, the curve dips near 144.94, corresponding to the CityLink Expressway section, confirming the relatively limited infrastructure coverage in this area. Furthermore, the KDE curve flattens at its extremes (144.91 and 144.99), indicating that the number of fire hydrants in these marginal areas is sparsely distributed and exhibits little variation. The KDE curve provides a visual understanding of the locations where firefighting facilities are concentrated, facilitating the scheduling and optimised layout of urban firefighting resources."
    ]
   },
   {
@@ -12489,9 +12489,9 @@
    "id": "a50e9624-0cca-4c98-9bd9-191a1fd3ebd5",
    "metadata": {},
    "source": [
-    "This heat map shows the spatial density of fire hydrants across longitude and latitude. The color gradient from light red to dark red indicates increasing hydrant density, with dark red areas representing the highest concentrations. High hydrant density is primarily concentrated near the following longitudes: 144.95 to 144.96 (near Montague and Cecil Streets) and 144.97 to 144.98 (near Haig and Therry Streets). These areas exhibit distinct red density peaks, indicating a high density of fire hydrants around these streets and intersections, likely due to commercial areas, transportation hubs, or high population density.  \n",
+    "This heat map shows the spatial density of fire hydrants across longitude and latitude. The colour gradient from light red to dark red indicates increasing hydrant density, with dark red areas representing the highest concentrations. High hydrant density is primarily concentrated near the following longitudes: 144.95 to 144.96 (near Montague and Cecil Streets) and 144.97 to 144.98 (near Haig and Therry Streets). These areas exhibit distinct red density peaks, indicating a high density of fire hydrants around these streets and intersections, likely due to commercial areas, transportation hubs, or high population density.  \n",
     "\n",
-    "Meanwhile, the western area between longitudes 144.91 to 144.93 (Salmon and Hall Streets) exhibits a relatively moderate density, indicating a relatively balanced distribution of hydrants within the area. Near 144.94 (CityLink), fire hydrants are relatively sparsely distributed and show less intense heat, likely due to being located on a city highway or in an area with few people. Furthermore, the legend used in the chart greatly enhances readability and spatial reference by labeling key longitudes with their corresponding streets (e.g., \"144.97 ≈ Haig St at Clarendon St\"), making it easier to compare hotspots with actual locations and facilitate further planning."
+    "Meanwhile, the western area between longitudes 144.91 to 144.93 (Salmon and Hall Streets) exhibits a relatively moderate density, indicating a relatively balanced distribution of hydrants within the area. Near 144.94 (CityLink), fire hydrants are relatively sparsely distributed and show less intense heat, likely due to being located on a city highway or in an area with few people. Furthermore, the legend used in the chart greatly enhances readability and spatial reference by labelling key longitudes with their corresponding streets (e.g., \"144.97 ≈ Haig St at Clarendon St\"), making it easier to compare hotspots with actual locations and facilitate further planning."
    ]
   },
   {


### PR DESCRIPTION
This PR adds the use case UC00196 under Playground/HanwenDun, including Jupyter Notebook for fire hydrant coverage analysis for Sprint 1.
