### PR TITLE
Redesign use case page 

### DIFF
--- a/next_webapp/src/app/[locale]/usecases/database.tsx
+++ b/next_webapp/src/app/[locale]/usecases/database.tsx
@@ -1,140 +1,82 @@
-// import { CATEGORY, CaseStudy } from "../../types";
+import { CaseStudy } from "../../types";
 
-// export const caseStudies: CaseStudy[] = [
-//   {
-//     id: 1,
-//     title: "Case Study 1",
-//     content: "Content for Case Study 1...",
-//     category: CATEGORY.INTERNET,
-//     filename: "Childcare_Facilities_Analysis",
-//   },
-//   {
-//     id: 2,
-//     title: "Case Study 2",
-//     content: "Content for Case Study 2...",
-//     category: CATEGORY.INTERNET,
-//     filename: "Projected_Music_venue_growth",
-//   },
-//   // Existing case studies
-//   {
-//     id: 3,
-//     title: "Case Study 3",
-//     content: "Content for Case Study 3...",
-//     category: CATEGORY.INTERNET,
-//   },
-//   {
-//     id: 4,
-//     title: "Case Study 4",
-//     content: "Content for Case Study 4...",
-//     category: CATEGORY.INTERNET,
-//   },
-//   {
-//     id: 5,
-//     title: "Case Study 5",
-//     content: "Content for Case Study 5...",
-//     category: CATEGORY.INTERNET,
-//   },
-//   {
-//     id: 6,
-//     title: "Case Study 6",
-//     content: "Content for Case Study 6...",
-//     category: CATEGORY.EV,
-//   },
-//   {
-//     id: 7,
-//     title: "Case Study 7",
-//     content: "Content for Case Study 7...",
-//     category: CATEGORY.EV,
-//   },
-//   {
-//     id: 8,
-//     title: "Case Study 8",
-//     content: "Content for Case Study 8...",
-//     category: CATEGORY.EV,
-//   },
-//   {
-//     id: 9,
-//     title: "Case Study 9",
-//     content: "Content for Case Study 9...",
-//     category: CATEGORY.EV,
-//   },
-//   {
-//     id: 10,
-//     title: "Case Study 10",
-//     content: "Content for Case Study 10...",
-//     category: CATEGORY.EV,
-//   },
-//   {
-//     id: 11,
-//     title: "Case Study 11",
-//     content: "Content for Case Study 11...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   {
-//     id: 12,
-//     title: "Case Study 12",
-//     content: "Content for Case Study 12...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   {
-//     id: 13,
-//     title: "Case Study 13",
-//     content: "Content for Case Study 13...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   {
-//     id: 14,
-//     title: "Case Study 14",
-//     content: "Content for Case Study 14...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   {
-//     id: 15,
-//     title: "Case Study 15",
-//     content: "Content for Case Study 15...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   {
-//     id: 16,
-//     title: "Case Study 16",
-//     content: "Content for Case Study 16...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   {
-//     id: 17,
-//     title: "Case Study 17",
-//     content: "Content for Case Study 17...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   {
-//     id: 18,
-//     title: "Case Study 18",
-//     content: "Content for Case Study 18...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   {
-//     id: 19,
-//     title: "Case Study 19",
-//     content: "Content for Case Study 19...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   {
-//     id: 20,
-//     title: "Case Study 20",
-//     content: "Content for Case Study 20...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   {
-//     id: 21,
-//     title: "Case Study 21",
-//     content: "Content for Case Study 21...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   {
-//     id: 22,
-//     title: "Case Study 22",
-//     content: "Content for Case Study 22...",
-//     category: CATEGORY.SECURITY,
-//   },
-//   // ...and so on until you reach the desired number of case studies
-// ];
+export const demoCaseStudies: CaseStudy[] = [
+  {
+    id: 1,
+    name: "Use Case Title Placeholder 1",
+    description:
+      "This is a placeholder description for the first use case card. It can later be replaced with real project content.",
+    tags: ["placeholder", "sample", "demo"],
+  },
+  {
+    id: 2,
+    name: "Use Case Title Placeholder 2",
+    description:
+      "This is a placeholder description for the second use case card. It is only used to demonstrate the tiled layout.",
+    tags: ["prototype", "ui", "card"],
+  },
+  {
+    id: 3,
+    name: "Use Case Title Placeholder 3",
+    description:
+      "This placeholder content helps test spacing, alignment, and consistent styling across different cards.",
+    tags: ["layout", "spacing", "design"],
+  },
+  {
+    id: 4,
+    name: "Use Case Title Placeholder 4",
+    description:
+      "This example card is used for responsive testing on tablet and mobile screen sizes.",
+    tags: ["responsive", "mobile", "tablet"],
+  },
+  {
+    id: 5,
+    name: "Use Case Title Placeholder 5",
+    description:
+      "This card provides sample content to preview how multiple cards will appear in a grid layout.",
+    tags: ["grid", "preview", "sample"],
+  },
+  {
+    id: 6,
+    name: "Use Case Title Placeholder 6",
+    description:
+      "This is another placeholder item for demonstrating a consistent card-based user interface.",
+    tags: ["consistency", "demo", "frontend"],
+  },
+  {
+    id: 7,
+    name: "Use Case Title Placeholder 7",
+    description:
+      "Placeholder data can later be replaced with real use cases from the backend or external files.",
+    tags: ["data", "mock", "replaceable"],
+  },
+  {
+    id: 8,
+    name: "Use Case Title Placeholder 8",
+    description:
+      "This sample entry is useful for testing how tag chips and descriptions wrap inside the card.",
+    tags: ["tags", "content", "testing"],
+  },
+  {
+    id: 9,
+    name: "Use Case Title Placeholder 9",
+    description:
+      "A final placeholder entry to make sure the card gallery feels complete and balanced during development.",
+    tags: ["final", "gallery", "placeholder"],
+  },
+
+    {
+    id: 10,
+    name: "Use Case Title Placeholder 10",
+    description:
+      "This placeholder card is added to demonstrate pagination and the appearance of a second page in the tiled card gallery.",
+    tags: ["pagination", "second page", "demo"],
+  },
+  {
+    id: 11,
+    name: "Use Case Title Placeholder 11",
+    description:
+      "This sample item helps test the layout and interaction of cards when the gallery spans across multiple pages.",
+    tags: ["multi-page", "layout", "testing"],
+  },
+];

--- a/next_webapp/src/app/[locale]/usecases/page.tsx
+++ b/next_webapp/src/app/[locale]/usecases/page.tsx
@@ -3,32 +3,21 @@
 import React, { useState, useEffect } from "react";
 import Header from "../../../components/Header";
 import Footer from "../../../components/Footer";
-import SearchBar from "./searchbar";
+import SearchBar, { LocalSearchMode } from "./searchbar";
 import PreviewComponent from "./preview";
-import { CATEGORY, SEARCH_MODE, SearchParams, CaseStudy } from "../../types";
-import { useTranslations } from "next-intl";
+import { CATEGORY, CaseStudy } from "../../types";
 import Tooglebutton from "../Tooglebutton/Tooglebutton";
-
-async function searchUseCases(params: SearchParams) {
-  const res = await fetch("/api/search-use-cases", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(params),
-  });
-  if (!res.ok) throw new Error(`Error ${res.status}`);
-  return res.json();
-}
+import { demoCaseStudies } from "./database";
 
 const UseCases: React.FC = () => {
-  const [filteredCaseStudies, setFilteredCaseStudies] = useState<CaseStudy[]>([]);
-  const [selectedCaseStudy, setSelectedCaseStudy] = useState<CaseStudy | null>(null);
+  const [allCaseStudies] = useState<CaseStudy[]>(demoCaseStudies);
+  const [filteredCaseStudies, setFilteredCaseStudies] =
+    useState<CaseStudy[]>(demoCaseStudies);
+  const [selectedCaseStudy, setSelectedCaseStudy] =
+    useState<CaseStudy | null>(null);
   const [darkMode, setDarkMode] = useState(false);
 
-  const t = useTranslations("usecases");
-
   useEffect(() => {
-    handleSearch("", SEARCH_MODE.TITLE, CATEGORY.ALL);
-
     const storedTheme = localStorage.getItem("theme");
     if (storedTheme === "dark") {
       setDarkMode(true);
@@ -49,44 +38,69 @@ const UseCases: React.FC = () => {
     localStorage.setItem("theme", value ? "dark" : "light");
   };
 
-  const handleSearch = async (
+  const handleSearch = (
     term: string,
-    mode: SEARCH_MODE,
+    mode: LocalSearchMode,
     cat: CATEGORY
   ) => {
-    try {
-      const res = await searchUseCases({
-        searchTerm: term,
-        searchMode: mode,
-        category: cat,
-      });
-      setFilteredCaseStudies(res.filteredStudies || []);
-    } catch (err) {
-      console.error("Search error:", err);
-      setFilteredCaseStudies([]);
+    const keyword = term.trim().toLowerCase();
+
+    if (!keyword) {
+      setFilteredCaseStudies(allCaseStudies);
+      setSelectedCaseStudy(null);
+      return;
     }
+
+    const filtered = allCaseStudies.filter((study) => {
+      if (mode === "title") {
+        return study.name?.toLowerCase().includes(keyword);
+      }
+
+      if (mode === "tag") {
+        return study.tags?.some((tag) => tag.toLowerCase().includes(keyword));
+      }
+
+      if (mode === "content") {
+        return study.description?.toLowerCase().includes(keyword);
+      }
+
+      return true;
+    });
+
+    setFilteredCaseStudies(filtered);
+    setSelectedCaseStudy(null);
   };
 
   return (
-    <div className="flex flex-col min-h-screen font-sans bg-white dark:bg-gray-800 text-black dark:text-white transition-all duration-300">
+    <div className="flex min-h-screen flex-col bg-[#f7f9fb] text-black transition-all duration-300 dark:bg-gray-900 dark:text-white">
       <Header />
+
       <main className="flex-grow">
-        <div className="max-w-7xl mx-auto px-4 lg:px-10">
-          <section className="py-5">
-            <h1 className="text-4xl font-bold mb-6">{t("User Cases")}</h1>
-            {!selectedCaseStudy && <SearchBar onSearch={handleSearch} />}
-            <PreviewComponent
-              caseStudies={filteredCaseStudies}
-              trendingCaseStudies={filteredCaseStudies}
-              selectedCaseStudy={selectedCaseStudy}
-              onSelectCaseStudy={setSelectedCaseStudy}
-              onBack={() => setSelectedCaseStudy(null)}
-            />
+        <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-10">
+          <section className="mb-8 rounded-[28px] border border-gray-200 bg-white px-6 py-8 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:px-8">
+            <div className="mb-4 inline-flex items-center rounded-full bg-green-50 px-4 py-1.5 text-sm font-semibold text-green-700 dark:bg-green-900/30 dark:text-green-300">
+              Open Data Use Cases
+            </div>
+
+            <div className="max-w-3xl">
+              <h1 className="mb-3 text-4xl font-bold tracking-tight sm:text-5xl">
+                Use Cases
+              </h1>
+            </div>
           </section>
+
+          {!selectedCaseStudy && <SearchBar onSearch={handleSearch} />}
+
+          <PreviewComponent
+            caseStudies={filteredCaseStudies}
+            trendingCaseStudies={filteredCaseStudies}
+            selectedCaseStudy={selectedCaseStudy}
+            onSelectCaseStudy={setSelectedCaseStudy}
+            onBack={() => setSelectedCaseStudy(null)}
+          />
         </div>
       </main>
 
-      {/* Dark Mode Toggle */}
       <div className="fixed bottom-4 right-4 z-50">
         <Tooglebutton onValueChange={handleToggle} />
       </div>

--- a/next_webapp/src/app/[locale]/usecases/preview.tsx
+++ b/next_webapp/src/app/[locale]/usecases/preview.tsx
@@ -1,77 +1,70 @@
-// app/usecases/preview.tsx
 "use client";
 
-import React, { useState } from "react";
-import { ArrowLeftCircle, ArrowRightCircle, FileText } from "lucide-react";
+import React, { useMemo, useState, useEffect } from "react";
+import {
+  ArrowLeftCircle,
+  ArrowRight,
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  Sparkles,
+} from "lucide-react";
 import { CaseStudy } from "../../types";
 
-const ITEMS_PER_PAGE = 6;
-const CARD_W = "w-full sm:w-[260px]"; // full-width on xs, 260px on sm+
-const CARD_H = "h-[180px]";
+const ITEMS_PER_PAGE = 9;
 
-////////////////////////////////////////////////////////////////////////////////
-// 1. Shared Card component
-////////////////////////////////////////////////////////////////////////////////
 interface CardProps {
   study: CaseStudy;
-  onClick?: () => void;
+  onClick: () => void;
 }
 
-const Card: React.FC<CardProps> = ({ study, onClick }) => (
-  <div
-    onClick={onClick}
-    className={`${CARD_W} ${CARD_H} overflow-hidden bg-white dark:bg-dark border border-gray-200 dark:border-gray-600 shadow hover:shadow-lg transition-shadow flex flex-col justify-between p-4 cursor-pointer`}
-  >
-    {/* Icon */}
-    <div className="flex justify-center mb-2">
-      <FileText size={48} className="text-primary" />
-      <FileText size={48} className="-ml-6 text-teal-400" />
-      <FileText size={48} className="-ml-6 rotate-6 text-green-700" />
-    </div>
+const UseCaseCard: React.FC<CardProps> = ({ study, onClick }) => {
+  const primaryTag = study.tags?.[0] || "Open Data";
 
-    {/* Title */}
-    <h3 className="text-sm font-semibold text-dark dark:text-white text-center whitespace-normal break-words">
-      {study.name}
-    </h3>
-
-    {/* Description */}
-    <p className="text-xs text-center text-gray-700 dark:text-gray-300 line-clamp-2">
-      {study.description}
-    </p>
-
-    {/* Tags */}
-    <div className="flex flex-wrap justify-center gap-1 mt-1">
-      {study.tags.slice(0, 3).map((t) => (
-        <span
-          key={t}
-          className="text-[10px] px-2 py-[1px] bg-gray-200 dark:bg-gray-600 text-gray-800 dark:text-white"
-        >
-          {t}
+  return (
+    <div
+      onClick={onClick}
+      className="group cursor-pointer rounded-[24px] border border-gray-200 bg-white p-5 shadow-sm transition duration-300 hover:-translate-y-1 hover:border-green-400 hover:shadow-xl dark:border-gray-700 dark:bg-gray-800"
+    >
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <span className="inline-flex rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700 dark:bg-green-900/30 dark:text-green-300">
+          {primaryTag}
         </span>
-      ))}
+
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-gray-100 text-green-600 dark:bg-gray-700 dark:text-green-300">
+          <FileText size={20} />
+        </div>
+      </div>
+
+      <h3 className="mb-3 text-xl font-bold leading-snug text-gray-900 dark:text-white">
+        {study.name}
+      </h3>
+
+      <p className="mb-5 min-h-[72px] text-sm leading-6 text-gray-600 dark:text-gray-300">
+        {study.description}
+      </p>
+
+      <div className="mb-5 flex flex-wrap gap-2">
+        {study.tags?.slice(0, 3).map((tag) => (
+          <span
+            key={tag}
+            className="rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs font-medium text-gray-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      <div className="flex items-center justify-between border-t border-gray-100 pt-4 dark:border-gray-700">
+        <span className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+          View overview
+        </span>
+        <ArrowRight className="text-green-600 transition group-hover:translate-x-1" size={18} />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
-////////////////////////////////////////////////////////////////////////////////
-// 2. Trending (hidden on <lg>, only first 2)
-////////////////////////////////////////////////////////////////////////////////
-interface TrendingProps {
-  trending: CaseStudy[];
-  onSelect: (s: CaseStudy) => void;
-}
-
-const Trending: React.FC<TrendingProps> = ({ trending, onSelect }) => (
-  <div className="flex flex-col space-y-6">
-    {trending.slice(0, 2).map((s) => (
-      <Card key={s.id} study={s} onClick={() => onSelect(s)} />
-    ))}
-  </div>
-);
-
-////////////////////////////////////////////////////////////////////////////////
-// 3. Main PreviewComponent
-////////////////////////////////////////////////////////////////////////////////
 interface Props {
   caseStudies: CaseStudy[];
   trendingCaseStudies: CaseStudy[];
@@ -82,100 +75,162 @@ interface Props {
 
 const PreviewComponent: React.FC<Props> = ({
   caseStudies,
-  trendingCaseStudies,
   selectedCaseStudy,
   onSelectCaseStudy,
   onBack,
 }) => {
   const [page, setPage] = useState(1);
 
-  // Detail view
+  useEffect(() => {
+    setPage(1);
+  }, [caseStudies]);
+
+  const totalPages = Math.ceil(caseStudies.length / ITEMS_PER_PAGE);
+
+  const visibleStudies = useMemo(() => {
+    const start = (page - 1) * ITEMS_PER_PAGE;
+    return caseStudies.slice(start, start + ITEMS_PER_PAGE);
+  }, [caseStudies, page]);
+
   if (selectedCaseStudy) {
     return (
-      <div className="flex flex-col min-h-screen p-8 bg-white dark:bg-[#263238]">
+      <section className="rounded-[28px] border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:p-8">
         <button
           onClick={onBack}
-          className="flex items-center text-primary mb-4 hover:text-primary/80"
+          className="mb-6 inline-flex items-center gap-2 rounded-full bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-700 transition hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
         >
-          <ArrowLeftCircle size={24} className="mr-2" /> Back
+          <ArrowLeftCircle size={18} />
+          Back to all use cases
         </button>
-        <div className="flex-grow overflow-auto bg-white dark:bg-dark shadow p-6">
-          <h1 className="text-3xl font-bold mb-4 text-dark dark:text-white">
-            {selectedCaseStudy.name}
-          </h1>
-          <iframe
-            src={`/api?filename=${selectedCaseStudy.filename}`}
-            title={selectedCaseStudy.name}
-            className="w-full h-[70vh] border-none"
-          />
+
+        <div className="mb-6 inline-flex items-center rounded-full bg-green-50 px-4 py-1.5 text-sm font-semibold text-green-700 dark:bg-green-900/30 dark:text-green-300">
+          <Sparkles size={16} className="mr-2" />
+          Selected Use Case
         </div>
-      </div>
+
+        <h2 className="mb-4 text-3xl font-bold text-gray-900 dark:text-white">
+          {selectedCaseStudy.name}
+        </h2>
+
+        <p className="mb-6 max-w-3xl text-base leading-7 text-gray-600 dark:text-gray-300">
+          {selectedCaseStudy.description}
+        </p>
+
+        <div className="mb-8 flex flex-wrap gap-3">
+          {selectedCaseStudy.tags?.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full border border-gray-200 bg-gray-50 px-4 py-2 text-sm font-medium text-gray-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="rounded-2xl bg-[#f7f9fb] p-5 dark:bg-gray-700">
+            <p className="mb-2 text-sm font-semibold text-gray-500 dark:text-gray-300">
+              Focus
+            </p>
+            <p className="text-base font-semibold text-gray-900 dark:text-white">
+              Practical open-data application
+            </p>
+          </div>
+
+          <div className="rounded-2xl bg-[#f7f9fb] p-5 dark:bg-gray-700">
+            <p className="mb-2 text-sm font-semibold text-gray-500 dark:text-gray-300">
+              Format
+            </p>
+            <p className="text-base font-semibold text-gray-900 dark:text-white">
+              Tiled case study preview
+            </p>
+          </div>
+
+          <div className="rounded-2xl bg-[#f7f9fb] p-5 dark:bg-gray-700">
+            <p className="mb-2 text-sm font-semibold text-gray-500 dark:text-gray-300">
+              Keywords
+            </p>
+            <p className="text-base font-semibold text-gray-900 dark:text-white">
+              {selectedCaseStudy.tags?.slice(0, 2).join(" • ") || "Open Data"}
+            </p>
+          </div>
+        </div>
+      </section>
     );
   }
 
-  // No results
   if (!caseStudies.length) {
-    return <p className="p-8 text-center text-lg">No use cases found.</p>;
+    return (
+      <section className="rounded-[28px] border border-dashed border-gray-300 bg-white px-6 py-16 text-center shadow-sm dark:border-gray-600 dark:bg-gray-800">
+        <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-green-50 text-green-600 dark:bg-green-900/30 dark:text-green-300">
+          <FileText size={28} />
+        </div>
+        <h2 className="mb-3 text-2xl font-bold text-gray-900 dark:text-white">
+          No use cases found
+        </h2>
+        <p className="mx-auto max-w-xl text-base leading-7 text-gray-600 dark:text-gray-300">
+          Try another keyword or search mode. You can also reset the filters to
+          explore all available use cases again.
+        </p>
+      </section>
+    );
   }
 
-  // Grid view
-  const totalPages = Math.ceil(caseStudies.length / ITEMS_PER_PAGE);
-  const visible = caseStudies.slice(
-    (page - 1) * ITEMS_PER_PAGE,
-    page * ITEMS_PER_PAGE
-  );
-
   return (
-    <div className="flex flex-col gap-8">
-      <div className="flex flex-col lg:flex-row gap-8">
-        {/* Trending sidebar */}
-        <aside className="hidden lg:block bg-gray-200 dark:bg-gray-700 p-6">
-          <h2 className="mb-4 text-lg font-semibold text-dark dark:text-white">
-            Trending
-          </h2>
-          <Trending
-            trending={trendingCaseStudies}
-            onSelect={onSelectCaseStudy}
-          />
-        </aside>
-
-        {/* Main grid */}
-        <div className="flex-1 bg-gray-200 dark:bg-gray-700 p-6">
-          <div className="grid gap-y-6 gap-x-8 grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 auto-rows-[180px] justify-items-center">
-            {visible.map((s) => (
-              <Card key={s.id} study={s} onClick={() => onSelectCaseStudy(s)} />
-            ))}
+    <div className="space-y-6">
+      <section className="rounded-[28px] border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:p-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="mb-2 text-sm font-semibold uppercase tracking-[0.2em] text-green-600 dark:text-green-300">
+              Case Study Gallery
+            </p>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+              Tiled showcase of use cases
+            </h2>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+              Showing {visibleStudies.length} of {caseStudies.length} use cases
+            </p>
           </div>
 
-          {totalPages > 1 && (
-            <div className="flex justify-center items-center space-x-4 mt-6">
-              <button
-                onClick={() => setPage(page - 1)}
-                disabled={page === 1}
-                className="disabled:opacity-50 p-1"
-              >
-                <ArrowLeftCircle
-                  size={20}
-                  className="text-dark dark:text-white"
-                />
-              </button>
-              <span className="text-xl font-semibold text-dark dark:text-white">
-                {page}
-              </span>
-              <button
-                onClick={() => setPage(page + 1)}
-                disabled={page === totalPages}
-                className="disabled:opacity-50 p-1"
-              >
-                <ArrowRightCircle
-                  size={20}
-                  className="text-dark dark:text-white"
-                />
-              </button>
-            </div>
-          )}
+          <div className="inline-flex items-center rounded-full bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-700 dark:bg-gray-700 dark:text-white">
+            Page {page} of {totalPages || 1}
+          </div>
         </div>
-      </div>
+      </section>
+
+      <section className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+        {visibleStudies.map((study) => (
+          <UseCaseCard
+            key={study.id}
+            study={study}
+            onClick={() => onSelectCaseStudy(study)}
+          />
+        ))}
+      </section>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={() => setPage((prev) => prev - 1)}
+            disabled={page === 1}
+            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
+          >
+            <ChevronLeft size={18} />
+          </button>
+
+          <span className="rounded-full bg-green-50 px-4 py-2 text-sm font-semibold text-green-700 dark:bg-green-900/30 dark:text-green-300">
+            {page}
+          </span>
+
+          <button
+            onClick={() => setPage((prev) => prev + 1)}
+            disabled={page === totalPages}
+            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
+          >
+            <ChevronRight size={18} />
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/next_webapp/src/app/[locale]/usecases/searchbar.tsx
+++ b/next_webapp/src/app/[locale]/usecases/searchbar.tsx
@@ -1,88 +1,73 @@
-// app/usecases/searchbar.tsx
-
 import React, { useState } from "react";
-import { CATEGORY, SEARCH_MODE } from "../../types";
-import { useTranslations } from "next-intl";
+import { CATEGORY } from "../../types";
 import { Search } from "lucide-react";
 
+export type LocalSearchMode = "title" | "tag" | "content";
+
 interface SearchBarProps {
-  onSearch: (term: string, mode: SEARCH_MODE, category: CATEGORY) => void;
+  onSearch: (term: string, mode: LocalSearchMode, category: CATEGORY) => void;
 }
 
 const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
   const [term, setTerm] = useState("");
-  // empty initial value so placeholder shows
-  const [mode, setMode] = useState<string>("");
-  const [category, setCategory] = useState<CATEGORY>(CATEGORY.ALL);
-  const t = useTranslations("usecases");
+  const [mode, setMode] = useState<LocalSearchMode>("title");
+  const [category] = useState<CATEGORY>(CATEGORY.ALL);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // if no mode selected, default to title
-    const selectedMode = (mode as SEARCH_MODE) || SEARCH_MODE.TITLE;
-    onSearch(term, selectedMode, category);
+    onSearch(term, mode, category);
+  };
+
+  const handleReset = () => {
+    setTerm("");
+    setMode("title");
+    onSearch("", "title", CATEGORY.ALL);
   };
 
   return (
-    <div className="bg-gray-100 dark:bg-gray-700 py-2 px-4 mb-8 rounded">
+    <div className="mb-8 rounded-[24px] border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:p-5">
       <form
         onSubmit={handleSubmit}
-        className="flex flex-col sm:flex-row sm:items-center sm:space-x-3"
+        className="flex flex-col gap-4 lg:flex-row lg:items-center"
       >
-        {/* SEARCH INPUT WITH ICON */}
         <div className="relative flex-1">
           <Search
             size={20}
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-700 dark:text-gray-300"
+            className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400"
           />
           <input
             type="search"
-            placeholder={t("Case study name or category")}
+            placeholder="Search use cases"
             value={term}
             onChange={(e) => setTerm(e.target.value)}
-            className="
-              w-full h-12
-              pl-10 pr-4
-              bg-transparent dark:bg-transparent
-              focus:outline-none focus:border-primary
-            "
+            className="h-14 w-full rounded-2xl border border-gray-200 bg-gray-50 pl-12 pr-4 text-sm outline-none transition focus:border-green-500 focus:bg-white dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:bg-gray-700"
           />
         </div>
 
-        {/* SELECT + BUTTON */}
-        <div className="mt-2 sm:mt-0 flex flex-col sm:flex-row sm:items-center sm:space-x-3">
+        <div className="flex flex-col gap-3 sm:flex-row">
           <select
             value={mode}
-            onChange={(e) => setMode(e.target.value)}
-            className="
-              h-12 px-4
-              bg-white dark:bg-gray-800
-              border border-gray-300 dark:border-gray-600
-              shadow
-              text-black dark:text-white
-              focus:outline-none focus:border-primary
-            "
+            onChange={(e) => setMode(e.target.value as LocalSearchMode)}
+            className="h-14 min-w-[210px] rounded-2xl border border-gray-200 bg-white px-4 text-sm outline-none transition focus:border-green-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
           >
-            {/* placeholder option */}
-            <option value="" disabled>
-              Search Category
-            </option>
-            <option value={SEARCH_MODE.TITLE}>Search by title</option>
-            <option value={SEARCH_MODE.CONTENT}>Search by tag</option>
+            <option value="title">Search by title</option>
+            <option value="tag">Search by tag</option>
+            <option value="content">Search by content</option>
           </select>
 
           <button
             type="submit"
-            className="
-              mt-2 sm:mt-0
-              h-12 px-4
-              bg-primary text-white
-              hover:bg-primary/90
-              focus:outline-none
-              rounded
-            "
+            className="h-14 rounded-2xl bg-primary px-6 text-sm font-semibold text-white transition hover:bg-primary/90"
           >
-            {t("Search")}
+            Search
+          </button>
+
+          <button
+            type="button"
+            onClick={handleReset}
+            className="h-14 rounded-2xl border border-gray-200 bg-white px-6 text-sm font-semibold text-gray-700 transition hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
+          >
+            Reset
           </button>
         </div>
       </form>

--- a/next_webapp/src/app/types.ts
+++ b/next_webapp/src/app/types.ts
@@ -8,6 +8,7 @@ export enum CATEGORY {
 export enum SEARCH_MODE {
   TITLE = "title",
   CONTENT = "content",
+  TAG = "tag"
 }
 
 export type SearchParams = {


### PR DESCRIPTION
This PR redesigns the Use Case page into a tiled card gallery for front-end presentation.

Main changes:

- restructured page.tsx to add a dedicated intro/showcase section
- rebuilt searchbar.tsx into a toolbar with title/tag/content search modes and reset support
- rebuilt preview.tsx to use a responsive tiled card grid instead of the previous display format
- added hover states, empty state, pagination, and in-page detail view
- added local placeholder data in database.tsx to support UI development and page preview

<img width="1919" height="988" alt="image" src="https://github.com/user-attachments/assets/f114413f-1ec7-498b-a5aa-ba701d1f15f4" />
<img width="1919" height="975" alt="image" src="https://github.com/user-attachments/assets/9d22014b-841c-4bc1-ae61-aca9f6032205" />
<img width="1830" height="836" alt="image" src="https://github.com/user-attachments/assets/499afa3d-e2e2-4452-85e8-a0542196da5d" />
<img width="1915" height="971" alt="image" src="https://github.com/user-attachments/assets/8c6568b1-f112-495d-bd30-c1ab6fd1eb52" />
