### PR TITLE
feat(mongo): add Mongoose models for all collections

### DIFF
--- a/next_webapp/src/lib/dbConnect.ts
+++ b/next_webapp/src/lib/dbConnect.ts
@@ -1,0 +1,60 @@
+import mongoose, { type Connection } from "mongoose";
+
+const MONGODB_URI = process.env.MONGODB_URI;
+
+interface MongooseCache {
+  conn: Connection | null;
+  promise: Promise<Connection> | null;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __mongooseCache: MongooseCache | undefined;
+}
+
+const cached: MongooseCache = global.__mongooseCache ?? {
+  conn: null,
+  promise: null,
+};
+
+if (!global.__mongooseCache) {
+  global.__mongooseCache = cached;
+}
+
+/**
+ * Cached Mongoose connection helper. Reuses a single connection pool across
+ * hot reloads (dev) and warm serverless invocations instead of opening a new
+ * one per call/import.
+ */
+export async function dbConnect(): Promise<Connection> {
+  if (!MONGODB_URI) {
+    throw new Error(
+      "Please define the MONGODB_URI environment variable inside .env",
+    );
+  }
+
+  if (cached.conn) {
+    return cached.conn;
+  }
+
+  if (!cached.promise) {
+    cached.promise = mongoose
+      .connect(MONGODB_URI, {
+        bufferCommands: false,
+        serverSelectionTimeoutMS: 10000,
+      })
+      .then((mongooseInstance) => mongooseInstance.connection);
+  }
+
+  try {
+    cached.conn = await cached.promise;
+  } catch (error) {
+    // Allow the next call to retry instead of replaying a rejected promise.
+    cached.promise = null;
+    throw error;
+  }
+
+  return cached.conn;
+}
+
+export default dbConnect;

--- a/next_webapp/src/models/mongoose/Blog.ts
+++ b/next_webapp/src/models/mongoose/Blog.ts
@@ -1,0 +1,34 @@
+import mongoose, { Schema, type InferSchemaType } from "mongoose";
+
+const blogSchema = new Schema(
+  {
+    // Old Postgres `blogs.id`, kept as a string during the migration window.
+    legacy_id: { type: String, default: null },
+
+    title: { type: String, required: true },
+    // No size cap: largest live document is ~3.5KB (see progress report),
+    // nowhere near the 16MB BSON document limit, but nothing here enforces
+    // an upper bound if that changes.
+    content: { type: String, default: null },
+    description: { type: String, default: null },
+    cover_img: { type: String, default: null },
+    published_date: { type: Date, default: null },
+
+    created_by: { type: Schema.Types.ObjectId, ref: "User", default: null },
+  },
+  {
+    collection: "blogs",
+    timestamps: { createdAt: "created_at", updatedAt: "updated_at" },
+  },
+);
+
+blogSchema.index({ legacy_id: 1 });
+blogSchema.index({ created_by: 1 });
+// Mirrors the existing live index on `published_date` (descending).
+blogSchema.index({ published_date: -1 });
+
+export type BlogDocument = InferSchemaType<typeof blogSchema>;
+
+export const Blog = mongoose.models.Blog || mongoose.model("Blog", blogSchema);
+
+export default Blog;

--- a/next_webapp/src/models/mongoose/Category.ts
+++ b/next_webapp/src/models/mongoose/Category.ts
@@ -1,0 +1,28 @@
+import mongoose, { Schema, type InferSchemaType } from "mongoose";
+
+const categorySchema = new Schema(
+  {
+    // Old Postgres `categories.id`, kept as a string during the migration window.
+    legacy_id: { type: String, default: null },
+
+    category_name: { type: String, required: true },
+    description: { type: String, default: null },
+    cover_img: { type: String, default: null },
+
+    created_by: { type: Schema.Types.ObjectId, ref: "User", default: null },
+  },
+  {
+    collection: "categories",
+    timestamps: { createdAt: "created_at", updatedAt: "updated_at" },
+  },
+);
+
+categorySchema.index({ legacy_id: 1 });
+categorySchema.index({ created_by: 1 });
+
+export type CategoryDocument = InferSchemaType<typeof categorySchema>;
+
+export const Category =
+  mongoose.models.Category || mongoose.model("Category", categorySchema);
+
+export default Category;

--- a/next_webapp/src/models/mongoose/GalleryImage.ts
+++ b/next_webapp/src/models/mongoose/GalleryImage.ts
@@ -1,0 +1,28 @@
+import mongoose, { Schema, type InferSchemaType } from "mongoose";
+
+const galleryImageSchema = new Schema(
+  {
+    // Old Postgres `gallery_images.id`, kept as a string during the migration window.
+    legacy_id: { type: String, default: null },
+
+    title: { type: String, default: null },
+    img_url: { type: String, required: true },
+
+    created_by: { type: Schema.Types.ObjectId, ref: "User", default: null },
+  },
+  {
+    collection: "gallery_images",
+    timestamps: { createdAt: "created_at", updatedAt: "updated_at" },
+  },
+);
+
+galleryImageSchema.index({ legacy_id: 1 });
+galleryImageSchema.index({ created_by: 1 });
+
+export type GalleryImageDocument = InferSchemaType<typeof galleryImageSchema>;
+
+export const GalleryImage =
+  mongoose.models.GalleryImage ||
+  mongoose.model("GalleryImage", galleryImageSchema);
+
+export default GalleryImage;

--- a/next_webapp/src/models/mongoose/Log.ts
+++ b/next_webapp/src/models/mongoose/Log.ts
@@ -1,0 +1,52 @@
+import mongoose, { Schema, type InferSchemaType } from "mongoose";
+
+// No `timestamps` option: the live `logs` collection only has `created_at`,
+// not an `updated_at` counterpart (log entries are never updated), so the
+// paired createdAt/updatedAt mapping used elsewhere doesn't apply here.
+const logSchema = new Schema(
+  {
+    // Old Postgres `logs.id`, kept as a string during the migration window.
+    legacy_id: { type: String, default: null },
+
+    // NOTE: live data has raw ANSI color-escape codes baked into `level` and
+    // `message` on 100% of documents (Winston console formatting leaked into
+    // persisted records) — see progress report. Not sanitized here; this
+    // schema types the field as-is, cleanup is a separate concern.
+    level: { type: String, required: true },
+    message: { type: String, required: true },
+    timestamp: { type: Date, required: true },
+
+    meta: { type: Schema.Types.Mixed, default: null },
+    source: { type: String, default: null },
+
+    user_id: { type: Schema.Types.ObjectId, ref: "User", default: null },
+    ip_address: { type: String, default: null },
+    user_agent: { type: String, default: null },
+    method: { type: String, default: null },
+    url: { type: String, default: null },
+    status_code: { type: Number, default: null },
+    // Live data: 0/3477 documents have a non-null response_time — always
+    // null in practice today, kept nullable rather than required.
+    response_time: { type: Number, default: null },
+
+    created_at: { type: Date, default: Date.now },
+  },
+  {
+    collection: "logs",
+  },
+);
+
+// Deliberately NOT declaring any index on `timestamp` here. The live
+// `logs` collection already has two indexes on that field — a plain
+// descending index (`timestamp_-1`) and a TTL index
+// (`timestamp_1`, expireAfterSeconds: 7776000) that expires log documents
+// after 90 days. Redeclaring either here risks Mongoose treating them as
+// out of sync on an autoIndex/syncIndexes pass. Left alone per instructions.
+logSchema.index({ user_id: 1 });
+logSchema.index({ legacy_id: 1 });
+
+export type LogDocument = InferSchemaType<typeof logSchema>;
+
+export const Log = mongoose.models.Log || mongoose.model("Log", logSchema);
+
+export default Log;

--- a/next_webapp/src/models/mongoose/Role.ts
+++ b/next_webapp/src/models/mongoose/Role.ts
@@ -1,0 +1,22 @@
+import mongoose, { Schema, type InferSchemaType } from "mongoose";
+
+const roleSchema = new Schema(
+  {
+    // Old Postgres `roles.id`, kept as a string during the migration window.
+    legacy_id: { type: String, default: null },
+    role_name: { type: String, required: true },
+  },
+  {
+    collection: "roles",
+    timestamps: { createdAt: "created_at", updatedAt: "updated_at" },
+  },
+);
+
+roleSchema.index({ legacy_id: 1 });
+roleSchema.index({ role_name: 1 }, { unique: true });
+
+export type RoleDocument = InferSchemaType<typeof roleSchema>;
+
+export const Role = mongoose.models.Role || mongoose.model("Role", roleSchema);
+
+export default Role;

--- a/next_webapp/src/models/mongoose/Tag.ts
+++ b/next_webapp/src/models/mongoose/Tag.ts
@@ -1,0 +1,27 @@
+import mongoose, { Schema, type InferSchemaType } from "mongoose";
+
+// No `timestamps` option: the live `tags` collection has no created_at/updated_at
+// fields at all (confirmed against all 128 documents) — do not invent them.
+const tagSchema = new Schema(
+  {
+    // Old Postgres `tags.id`, kept as a string during the migration window.
+    legacy_id: { type: String, default: null },
+
+    name: { type: String, required: true },
+    slug: { type: String, required: true },
+  },
+  {
+    collection: "tags",
+  },
+);
+
+tagSchema.index({ legacy_id: 1 });
+// Mirrors the existing live unique index on `slug` — confirmed 0 duplicate
+// slugs across all 128 live documents before adding this.
+tagSchema.index({ slug: 1 }, { unique: true });
+
+export type TagDocument = InferSchemaType<typeof tagSchema>;
+
+export const Tag = mongoose.models.Tag || mongoose.model("Tag", tagSchema);
+
+export default Tag;

--- a/next_webapp/src/models/mongoose/UseCase.ts
+++ b/next_webapp/src/models/mongoose/UseCase.ts
@@ -1,0 +1,66 @@
+import mongoose, { Schema, type InferSchemaType } from "mongoose";
+
+// Embedded, denormalized reference to a category document — not populated
+// via a Mongoose `ref` walk by default, just carries the id + a display copy.
+const CategoryRefSchema = new Schema(
+  {
+    id: { type: Schema.Types.ObjectId, ref: "Category" },
+    legacy_id: { type: String, default: null },
+    category_name: { type: String, default: null },
+  },
+  { _id: false },
+);
+
+// Embedded, denormalized reference to a tag document.
+const TagRefSchema = new Schema(
+  {
+    id: { type: Schema.Types.ObjectId, ref: "Tag" },
+    legacy_id: { type: String, default: null },
+    name: { type: String, default: null },
+    slug: { type: String, default: null },
+  },
+  { _id: false },
+);
+
+const useCaseSchema = new Schema(
+  {
+    // Old Postgres `usecases.id`, kept as a string during the migration
+    // window so legacy references (e.g. `?legacy_id=24`) still resolve.
+    legacy_id: { type: String, default: null },
+
+    title: { type: String, required: true },
+    description: { type: String, default: null },
+    cover_img: { type: String, default: null },
+
+    // Reference to a GridFS file holding the notebook/HTML body. Deliberately
+    // NOT a Mongoose `ref` — GridFS files aren't a model, they're chunks in
+    // `<bucket>.files`/`<bucket>.chunks`, looked up manually via GridFSBucket.
+    content_file_id: { type: Schema.Types.ObjectId, default: null },
+    content_type: {
+      type: String,
+      enum: ["notebook", "html", null],
+      default: null,
+    },
+
+    category: { type: CategoryRefSchema, default: null },
+    tags: { type: [TagRefSchema], default: [] },
+
+    created_by: { type: Schema.Types.ObjectId, ref: "User", default: null },
+  },
+  {
+    collection: "usecases",
+    timestamps: { createdAt: "created_at", updatedAt: "updated_at" },
+  },
+);
+
+useCaseSchema.index({ "category.id": 1 });
+useCaseSchema.index({ "tags.slug": 1 });
+useCaseSchema.index({ created_by: 1 });
+useCaseSchema.index({ legacy_id: 1 });
+
+export type UseCaseDocument = InferSchemaType<typeof useCaseSchema>;
+
+export const UseCase =
+  mongoose.models.UseCase || mongoose.model("UseCase", useCaseSchema);
+
+export default UseCase;

--- a/next_webapp/src/models/mongoose/User.ts
+++ b/next_webapp/src/models/mongoose/User.ts
@@ -1,0 +1,52 @@
+import mongoose, { Schema, type InferSchemaType } from "mongoose";
+
+// Embedded, denormalized reference to a role document — same pattern as
+// UseCase's CategoryRefSchema: carries the ObjectId ref plus a display copy,
+// not just a bare `role_id` scalar.
+const RoleRefSchema = new Schema(
+  {
+    id: { type: Schema.Types.ObjectId, ref: "Role" },
+    legacy_id: { type: String, default: null },
+    role_name: { type: String, default: null },
+  },
+  { _id: false },
+);
+
+const ProfileSchema = new Schema(
+  {
+    first_name: { type: String, default: null },
+    last_name: { type: String, default: null },
+    age: { type: Number, default: null },
+    gender: { type: String, default: null },
+    profile_img: { type: String, default: null },
+    updated_at: { type: Date, default: null },
+  },
+  { _id: false },
+);
+
+const userSchema = new Schema(
+  {
+    // Old Postgres `user.id`, kept as a string during the migration window.
+    legacy_id: { type: String, default: null },
+
+    email: { type: String, required: true },
+    password: { type: String, required: true },
+
+    role: { type: RoleRefSchema, default: null },
+    profile: { type: ProfileSchema, default: null },
+  },
+  {
+    collection: "users",
+    timestamps: { createdAt: "created_at", updatedAt: "updated_at" },
+  },
+);
+
+userSchema.index({ email: 1 }, { unique: true });
+userSchema.index({ "role.id": 1 });
+userSchema.index({ legacy_id: 1 });
+
+export type UserDocument = InferSchemaType<typeof userSchema>;
+
+export const User = mongoose.models.User || mongoose.model("User", userSchema);
+
+export default User;


### PR DESCRIPTION
Adds Mongoose models for all 8 collections in mop_database, plus a cached connection helper. This is the Phase 1 (data model) deliverable for the Postgres→MongoDB migration.

Files added:

Connection helper:

next_webapp/src/lib/dbConnect.ts connects the app to MongoDB and reuses the connection instead of opening a new one every time

Models (one per collection):

next_webapp/src/models/mongoose/UseCase.ts
next_webapp/src/models/mongoose/User.ts
next_webapp/src/models/mongoose/Role.ts
next_webapp/src/models/mongoose/Category.ts
next_webapp/src/models/mongoose/Tag.ts
next_webapp/src/models/mongoose/GalleryImage.ts
next_webapp/src/models/mongoose/Blog.ts
next_webapp/src/models/mongoose/Log.ts

Roles: modeled as a collection + embedded ref, not inlined. We'd earlier considered inlining role onto users, but live data showed roles is a real populated collection that users reference via an embedded { id, legacy_id, role_name } object same pattern as usecases.category. Matched the data rather than forcing the inline design. (So 8 collections, not 7.)

Usecase content → GridFS-ready. The schema declares content_file_id + content_type instead of inline content, to get past MongoDB's 16MB limit (usecase id 33 is 22.5MB). The actual GridFS data migration is Phase 2 work see note below.

Timestamps mapped to existing created_at/updated_at where present; omitted for Tag/Log which genuinely lack the paired fields.

Only genuinely-required fields marked required, to avoid rejecting valid existing documents that have nulls.

Not touched: the legacy src/mongodb/ Mongoose files and src/models/Category.ts (Postgres interface) both left for Phase 4 cleanup / separate concern.