### PR TITLE
feat(contributors): Contributors API model + CRUD endpoints

### DIFF
--- a/next_webapp/src/app/api/contributors/[id]/route.ts
+++ b/next_webapp/src/app/api/contributors/[id]/route.ts
@@ -59,8 +59,11 @@ export async function PUT(
     let body;
     try {
       body = await request.json();
-    } catch {
-      return errorResponse("Invalid JSON in request body.", 400, "INVALID_JSON", request);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return errorResponse("Invalid JSON in request body.", 400, "INVALID_JSON", request);
+      }
+      throw error;
     }
 
     await dbConnect();

--- a/next_webapp/src/app/api/contributors/[id]/route.ts
+++ b/next_webapp/src/app/api/contributors/[id]/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from "next/server";
+import mongoose from "mongoose";
+import dbConnect from "@/lib/dbConnect";
+import Contributor from "@/models/mongoose/Contributor";
+import { getAuthUser } from "@/app/api/library/auth";
+import { errorResponse } from "@/app/api/library/errorResponse";
+
+// Map a Mongo document (or .lean() object) to the flat, snake_case shape the
+// frontend expects plain string `id`, never a raw `_id`/`__v`.
+function toContributorDTO(doc: any) {
+  const { _id, __v, ...rest } = doc;
+  return { id: _id.toString(), ...rest };
+}
+
+// ==============================
+// GET /api/contributors/:id
+// Fetch a single contributor (PUBLIC)
+// ==============================
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return errorResponse("Invalid contributor ID", 400, "INVALID_ID");
+    }
+
+    await dbConnect();
+
+    const contributor = await Contributor.findById(id).lean();
+    if (!contributor) {
+      return errorResponse("Contributor not found", 404, "NOT_FOUND");
+    }
+
+    return NextResponse.json({ success: true, data: toContributorDTO(contributor) });
+  } catch (error) {
+    console.error("Get Contributor Error:", error);
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR");
+  }
+}
+
+// ==============================
+// PUT /api/contributors/:id
+// Update a contributor (ADMIN ONLY)
+// ==============================
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { isAuthenticated, isAdmin } = getAuthUser(request);
+    if (!isAuthenticated) {
+      return errorResponse("User not authenticated", 401, "UNAUTHORIZED");
+    }
+    if (!isAdmin) {
+      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN");
+    }
+
+    const { id } = await params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return errorResponse("Invalid contributor ID", 400, "INVALID_ID");
+    }
+
+    const body = await request.json();
+
+    await dbConnect();
+
+    const existing = await Contributor.findById(id);
+    if (!existing) {
+      return errorResponse("Contributor not found", 404, "NOT_FOUND");
+    }
+
+    existing.set({
+      name: body.name,
+      year: body.year,
+      trimester: body.trimester,
+      contributor_type: body.contributor_type,
+      team: body.team ?? null,
+      position: body.position ?? null,
+      level: body.level ?? null,
+      display_order: body.display_order ?? 0,
+      is_active: body.is_active ?? true,
+    });
+
+    await existing.save();
+
+    return NextResponse.json({ success: true, data: toContributorDTO(existing.toObject()) });
+  } catch (error) {
+    if (error instanceof Error && error.name === "ValidationError") {
+      return errorResponse(error.message, 400, "VALIDATION_ERROR");
+    }
+    console.error("Update Contributor Error:", error);
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR");
+  }
+}
+
+// ==============================
+// DELETE /api/contributors/:id
+// Delete a contributor (ADMIN ONLY)
+// ==============================
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { isAuthenticated, isAdmin } = getAuthUser(request);
+    if (!isAuthenticated) {
+      return errorResponse("User not authenticated", 401, "UNAUTHORIZED");
+    }
+    if (!isAdmin) {
+      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN");
+    }
+
+    const { id } = await params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return errorResponse("Invalid contributor ID", 400, "INVALID_ID");
+    }
+
+    await dbConnect();
+
+    const deleted = await Contributor.findByIdAndDelete(id);
+    if (!deleted) {
+      return errorResponse("Contributor not found", 404, "NOT_FOUND");
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "Contributor deleted successfully",
+    });
+  } catch (error) {
+    console.error("Delete Contributor Error:", error);
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR");
+  }
+}

--- a/next_webapp/src/app/api/contributors/[id]/route.ts
+++ b/next_webapp/src/app/api/contributors/[id]/route.ts
@@ -4,39 +4,33 @@ import dbConnect from "@/lib/dbConnect";
 import Contributor from "@/models/mongoose/Contributor";
 import { getAuthUser } from "@/app/api/library/auth";
 import { errorResponse } from "@/app/api/library/errorResponse";
-
-// Map a Mongo document (or .lean() object) to the flat, snake_case shape the
-// frontend expects plain string `id`, never a raw `_id`/`__v`.
-function toContributorDTO(doc: any) {
-  const { _id, __v, ...rest } = doc;
-  return { id: _id.toString(), ...rest };
-}
+import { toContributorDTO } from "@/app/api/library/contributorDto";
 
 // ==============================
 // GET /api/contributors/:id
 // Fetch a single contributor (PUBLIC)
 // ==============================
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     const { id } = await params;
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      return errorResponse("Invalid contributor ID", 400, "INVALID_ID");
+      return errorResponse("Invalid contributor ID", 400, "INVALID_ID", request);
     }
 
     await dbConnect();
 
     const contributor = await Contributor.findById(id).lean();
     if (!contributor) {
-      return errorResponse("Contributor not found", 404, "NOT_FOUND");
+      return errorResponse("Contributor not found", 404, "NOT_FOUND", request);
     }
 
     return NextResponse.json({ success: true, data: toContributorDTO(contributor) });
   } catch (error) {
     console.error("Get Contributor Error:", error);
-    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR");
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request);
   }
 }
 
@@ -51,24 +45,29 @@ export async function PUT(
   try {
     const { isAuthenticated, isAdmin } = getAuthUser(request);
     if (!isAuthenticated) {
-      return errorResponse("User not authenticated", 401, "UNAUTHORIZED");
+      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request);
     }
     if (!isAdmin) {
-      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN");
+      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request);
     }
 
     const { id } = await params;
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      return errorResponse("Invalid contributor ID", 400, "INVALID_ID");
+      return errorResponse("Invalid contributor ID", 400, "INVALID_ID", request);
     }
 
-    const body = await request.json();
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return errorResponse("Invalid JSON in request body.", 400, "INVALID_JSON", request);
+    }
 
     await dbConnect();
 
     const existing = await Contributor.findById(id);
     if (!existing) {
-      return errorResponse("Contributor not found", 404, "NOT_FOUND");
+      return errorResponse("Contributor not found", 404, "NOT_FOUND", request);
     }
 
     existing.set({
@@ -88,10 +87,10 @@ export async function PUT(
     return NextResponse.json({ success: true, data: toContributorDTO(existing.toObject()) });
   } catch (error) {
     if (error instanceof Error && error.name === "ValidationError") {
-      return errorResponse(error.message, 400, "VALIDATION_ERROR");
+      return errorResponse(error.message, 400, "VALIDATION_ERROR", request);
     }
     console.error("Update Contributor Error:", error);
-    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR");
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request);
   }
 }
 
@@ -106,22 +105,22 @@ export async function DELETE(
   try {
     const { isAuthenticated, isAdmin } = getAuthUser(request);
     if (!isAuthenticated) {
-      return errorResponse("User not authenticated", 401, "UNAUTHORIZED");
+      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request);
     }
     if (!isAdmin) {
-      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN");
+      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request);
     }
 
     const { id } = await params;
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      return errorResponse("Invalid contributor ID", 400, "INVALID_ID");
+      return errorResponse("Invalid contributor ID", 400, "INVALID_ID", request);
     }
 
     await dbConnect();
 
     const deleted = await Contributor.findByIdAndDelete(id);
     if (!deleted) {
-      return errorResponse("Contributor not found", 404, "NOT_FOUND");
+      return errorResponse("Contributor not found", 404, "NOT_FOUND", request);
     }
 
     return NextResponse.json({
@@ -130,6 +129,6 @@ export async function DELETE(
     });
   } catch (error) {
     console.error("Delete Contributor Error:", error);
-    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR");
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request);
   }
 }

--- a/next_webapp/src/app/api/contributors/route.ts
+++ b/next_webapp/src/app/api/contributors/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import dbConnect from "@/lib/dbConnect";
+import Contributor from "@/models/mongoose/Contributor";
+import { getAuthUser } from "@/app/api/library/auth";
+import { errorResponse } from "@/app/api/library/errorResponse";
+
+// Map a Mongo document (or .lean() object) to the flat, snake_case shape the
+// frontend expects plain string `id`, never a raw `_id`/`__v`.
+function toContributorDTO(doc: any) {
+  const { _id, __v, ...rest } = doc;
+  return { id: _id.toString(), ...rest };
+}
+
+// ==============================
+// GET /api/contributors
+// List all contributors (PUBLIC the display page reads this unauthenticated)
+// ==============================
+export async function GET() {
+  try {
+    await dbConnect();
+
+    const contributors = await Contributor.find({})
+      .sort({ year: -1, trimester: 1, display_order: 1 })
+      .lean();
+
+    return NextResponse.json({
+      success: true,
+      data: contributors.map(toContributorDTO),
+    });
+  } catch (error) {
+    console.error("List Contributors Error:", error);
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR");
+  }
+}
+
+// ==============================
+// POST /api/contributors
+// Create a contributor (ADMIN ONLY)
+// ==============================
+export async function POST(request: NextRequest) {
+  try {
+    const { isAuthenticated, isAdmin } = getAuthUser(request);
+    if (!isAuthenticated) {
+      return errorResponse("User not authenticated", 401, "UNAUTHORIZED");
+    }
+    if (!isAdmin) {
+      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN");
+    }
+
+    const body = await request.json();
+
+    await dbConnect();
+
+    const created = await Contributor.create({
+      name: body.name,
+      year: body.year,
+      trimester: body.trimester,
+      contributor_type: body.contributor_type,
+      team: body.team ?? null,
+      position: body.position ?? null,
+      level: body.level ?? null,
+      display_order: body.display_order ?? 0,
+      is_active: body.is_active ?? true,
+    });
+
+    return NextResponse.json(
+      { success: true, data: toContributorDTO(created.toObject()) },
+      { status: 201 },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.name === "ValidationError") {
+      return errorResponse(error.message, 400, "VALIDATION_ERROR");
+    }
+    console.error("Create Contributor Error:", error);
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR");
+  }
+}

--- a/next_webapp/src/app/api/contributors/route.ts
+++ b/next_webapp/src/app/api/contributors/route.ts
@@ -44,8 +44,11 @@ export async function POST(request: NextRequest) {
     let body;
     try {
       body = await request.json();
-    } catch {
-      return errorResponse("Invalid JSON in request body.", 400, "INVALID_JSON", request);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return errorResponse("Invalid JSON in request body.", 400, "INVALID_JSON", request);
+      }
+      throw error;
     }
 
     await dbConnect();

--- a/next_webapp/src/app/api/contributors/route.ts
+++ b/next_webapp/src/app/api/contributors/route.ts
@@ -3,19 +3,13 @@ import dbConnect from "@/lib/dbConnect";
 import Contributor from "@/models/mongoose/Contributor";
 import { getAuthUser } from "@/app/api/library/auth";
 import { errorResponse } from "@/app/api/library/errorResponse";
-
-// Map a Mongo document (or .lean() object) to the flat, snake_case shape the
-// frontend expects plain string `id`, never a raw `_id`/`__v`.
-function toContributorDTO(doc: any) {
-  const { _id, __v, ...rest } = doc;
-  return { id: _id.toString(), ...rest };
-}
+import { toContributorDTO } from "@/app/api/library/contributorDto";
 
 // ==============================
 // GET /api/contributors
 // List all contributors (PUBLIC the display page reads this unauthenticated)
 // ==============================
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     await dbConnect();
 
@@ -29,7 +23,7 @@ export async function GET() {
     });
   } catch (error) {
     console.error("List Contributors Error:", error);
-    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR");
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request);
   }
 }
 
@@ -41,13 +35,18 @@ export async function POST(request: NextRequest) {
   try {
     const { isAuthenticated, isAdmin } = getAuthUser(request);
     if (!isAuthenticated) {
-      return errorResponse("User not authenticated", 401, "UNAUTHORIZED");
+      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request);
     }
     if (!isAdmin) {
-      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN");
+      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request);
     }
 
-    const body = await request.json();
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return errorResponse("Invalid JSON in request body.", 400, "INVALID_JSON", request);
+    }
 
     await dbConnect();
 
@@ -69,9 +68,9 @@ export async function POST(request: NextRequest) {
     );
   } catch (error) {
     if (error instanceof Error && error.name === "ValidationError") {
-      return errorResponse(error.message, 400, "VALIDATION_ERROR");
+      return errorResponse(error.message, 400, "VALIDATION_ERROR", request);
     }
     console.error("Create Contributor Error:", error);
-    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR");
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request);
   }
 }

--- a/next_webapp/src/app/api/library/contributorDto.ts
+++ b/next_webapp/src/app/api/library/contributorDto.ts
@@ -1,0 +1,6 @@
+// Map a Mongo document (or .lean() object) to the flat shape the frontend
+// expects — plain string `id`, never a raw `_id`/`__v`.
+export function toContributorDTO(doc: any) {
+  const { _id, __v, ...rest } = doc;
+  return { id: _id.toString(), ...rest };
+}

--- a/next_webapp/src/middleware.ts
+++ b/next_webapp/src/middleware.ts
@@ -86,6 +86,13 @@ async function verifyJWT(
 
     const [headerB64, payloadB64, signatureB64] = parts;
 
+    // Reject any token whose header doesn't declare exactly HS256/JWT this
+    // blocks algorithm-confusion attacks (e.g. "alg": "none" or RS256 with a
+    // public key used as the HMAC secret).
+    const headerJson = new TextDecoder().decode(base64urlDecode(headerB64));
+    const header = JSON.parse(headerJson) as Record<string, unknown>;
+    if (header.alg !== "HS256" || header.typ !== "JWT") return null;
+
     // Import the HMAC-SHA256 secret key
     const keyData = new TextEncoder().encode(secret);
     const cryptoKey = await crypto.subtle.importKey(

--- a/next_webapp/src/middleware.ts
+++ b/next_webapp/src/middleware.ts
@@ -14,7 +14,7 @@ const intlMiddleware = createMiddleware({
  * Page paths that require a valid JWT.
  * Matched against the path with any locale prefix stripped.
  */
-const PROTECTED_PATHS = ["/dashboard", "/admin", "/upload", "/statistics", "/api/profile", "/api/categories", "/api/blogs", "/api/gallery", "/api/logs", "/api/admin", "/api/upload"];
+const PROTECTED_PATHS = ["/dashboard", "/admin", "/upload", "/statistics", "/api/profile", "/api/categories", "/api/blogs", "/api/gallery", "/api/logs", "/api/admin", "/api/upload", "/api/contributors"];
 /**
  * Paths that are always publicly accessible and skip every auth check.
  * Matched against the bare path (locale prefix stripped).
@@ -40,6 +40,17 @@ function getBarePath(pathname: string): string {
 function isProtectedPath(pathname: string): boolean {
   const bare = getBarePath(pathname);
   return PROTECTED_PATHS.some((p) => bare === p || bare.startsWith(`${p}/`));
+}
+
+/**
+ * GET requests on /api/contributors (list) or /api/contributors/:id (single)
+ * are public the display page reads them with no login. Only the write
+ * methods on this same path family require the JWT check below.
+ */
+function isPublicContributorsRead(pathname: string, method: string): boolean {
+  if (method !== "GET") return false;
+  const bare = getBarePath(pathname);
+  return bare === "/api/contributors" || /^\/api\/contributors\/[^/]+$/.test(bare);
 }
 
 // Return true when the request should bypass auth entirely.
@@ -159,6 +170,12 @@ export default async function middleware(request: NextRequest) {
     return intlMiddleware(request);
   }
 
+  // 3.5 Public reads within an otherwise-protected path family (contributors
+  //     GET) bypass the JWT check, no user headers get attached.
+  if (isPublicContributorsRead(pathname, method)) {
+    return NextResponse.next();
+  }
+
   // 4. Protected API route: verify the JWT
   const JWT_SECRET = process.env.JWT_SECRET;
   if (!JWT_SECRET) {
@@ -232,6 +249,11 @@ export const config = {
 
     // Protected API routes — admin
     "/api/admin/:path*",
+
+    // Contributors GET is public (see isPublicContributorsRead), but the
+    // path still needs to be matched so POST/PUT/DELETE get JWT-verified.
+    "/api/contributors",
+    "/api/contributors/:path*",
 
     // Protected API routes — upload
     "/api/upload",

--- a/next_webapp/src/models/mongoose/Contributor.ts
+++ b/next_webapp/src/models/mongoose/Contributor.ts
@@ -1,0 +1,84 @@
+import mongoose, { Schema, type InferSchemaType } from "mongoose";
+
+// Fixed vocabularies the team-agreed taxonomy (supersedes the earlier
+// placeholder values copied from the admin form's old dropdown).
+export const TEAMS = [
+  "Data Science Team",
+  "Website Development Team",
+  "Design Team",
+  "Cyber Security Team",
+] as const;
+export const ROLES = [
+  "Web Developer",
+  "Data Scientist",
+  "Data Science Team Lead",
+  "Data Science Quality Manager",
+  "Web Dev Team Lead",
+  "Web Dev Quality Manager",
+  "Design Team Member",
+  "Design Team Lead",
+  "Cyber Security Team Member",
+  "Cyber Security Team Lead",
+] as const;
+export const LEVELS = ["Junior", "Senior"] as const;
+export const CONTRIBUTOR_TYPES = ["student", "mentor", "company_director"] as const;
+
+const contributorSchema = new Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    year: { type: Number, required: true },
+    trimester: { type: Number, required: true, enum: [1, 2, 3] },
+    contributor_type: {
+      type: String,
+      required: true,
+      enum: CONTRIBUTOR_TYPES,
+    },
+
+    // Only meaningful for students forced to null for mentors/directors
+    // by the pre-validate hook below, regardless of what's submitted.
+    team: { type: String, enum: [...TEAMS, null], default: null },
+    position: { type: String, enum: [...ROLES, null], default: null },
+    level: { type: String, enum: [...LEVELS, null], default: null },
+
+    display_order: { type: Number, default: 0 },
+    is_active: { type: Boolean, default: true },
+  },
+  {
+    collection: "contributors",
+    timestamps: { createdAt: "created_at", updatedAt: "updated_at" },
+  },
+);
+
+// Student/mentor/director rules: only students carry team/position/level.
+// Non-students are silently normalized to null (matches what the admin form
+// already does client-side for mentor/director submissions); students must
+// supply all three.
+contributorSchema.pre("validate", function (next) {
+  if (this.contributor_type !== "student") {
+    this.team = null;
+    this.position = null;
+    this.level = null;
+  } else {
+    if (!this.team) {
+      this.invalidate("team", "team is required for student contributors");
+    }
+    if (!this.position) {
+      this.invalidate("position", "position is required for student contributors");
+    }
+    if (!this.level) {
+      this.invalidate("level", "level is required for student contributors");
+    }
+  }
+  next();
+});
+
+contributorSchema.index({ year: -1, trimester: 1, display_order: 1 });
+contributorSchema.index({ contributor_type: 1 });
+contributorSchema.index({ team: 1 });
+
+export type ContributorDocument = InferSchemaType<typeof contributorSchema>;
+
+export const Contributor =
+  mongoose.models.Contributor || mongoose.model("Contributor", contributorSchema);
+
+export default Contributor;


### PR DESCRIPTION
A MongoDB model and a full CRUD API for contributors.

- src/models/mongoose/Contributor.ts the data model. Flat structure (one document per person), with the agreed team/role taxonomy enforced as enums. Exports TEAMS (4), ROLES (10), LEVELS, CONTRIBUTOR_TYPES so the admin form can import the same lists instead of hardcoding them.

- src/app/api/contributors/route.ts: GET (list all, public) and POST (create, admin-only).

- src/app/api/contributors/[id]/route.ts: GET, PUT, DELETE for a single contributor.