### PR TITLE
WD: feat migrate logs from Supabase to MongoDB

### DIFF
--- a/next_webapp/src/__tests__/api/logs/logs.test.ts
+++ b/next_webapp/src/__tests__/api/logs/logs.test.ts
@@ -1,24 +1,40 @@
 /**
  * @jest-environment node
  *
- * Tests for GET /api/logs
- * All Supabase calls and logger calls are mocked — no real DB or I/O work here.
+ * Tests for the MongoDB-backed /api/logs routes.
  */
-
-// ─── Mocks ──────────────────────────────────────────────────────────────────
 
 jest.mock('next/server', () => ({
   NextResponse: {
-    json: jest.fn().mockImplementation((body: unknown, init?: { status?: number }) => ({
-      status: init?.status ?? 200,
-      json: jest.fn().mockResolvedValue(body),
-      _body: body,
-    })),
+    json: jest.fn().mockImplementation(
+      (body: unknown, init?: { status?: number }) => ({
+        status: init?.status ?? 200,
+        json: jest.fn().mockResolvedValue(body),
+        _body: body,
+      }),
+    ),
   },
 }));
 
-jest.mock('@/library/supabaseClient', () => ({
-  supabase: { from: jest.fn() },
+jest.mock('@/lib/dbConnect', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@/models/mongoose/Log', () => ({
+  __esModule: true,
+  default: {
+    find: jest.fn(),
+    countDocuments: jest.fn(),
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('@/models/mongoose/User', () => ({
+  __esModule: true,
+  default: {
+    findOne: jest.fn(),
+  },
 }));
 
 jest.mock('@/app/api/library/auth', () => ({
@@ -34,80 +50,153 @@ jest.mock('@/utils/logger', () => ({
   },
 }));
 
-// ─── Imports ─────────────────────────────────────────────────────────────────
-
-import { GET } from '../../../app/api/logs/route';
-import { supabase } from '@/library/supabaseClient';
+import { Types } from 'mongoose';
+import { GET, DELETE } from '../../../app/api/logs/route';
+import dbConnect from '@/lib/dbConnect';
+import Log from '@/models/mongoose/Log';
+import User from '@/models/mongoose/User';
 import { getAuthUser } from '@/app/api/library/auth';
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
 function makeRequest(url = 'http://localhost:3000/api/logs') {
-  return { url, headers: { get: () => null } } as any;
+  return {
+    url,
+    headers: {
+      get: () => null,
+    },
+  } as any;
 }
 
-// The logs route applies filters AFTER .range(), so .range() must return the
-// chain itself (not a Promise). The chain is made directly awaitable via .then.
-function makeChain(result: { data: unknown; error: unknown; count?: number | null }) {
+function makeFindChain(result: unknown[]) {
   const chain: Record<string, jest.Mock> = {};
-  chain.select = jest.fn().mockReturnValue(chain);
-  chain.order  = jest.fn().mockReturnValue(chain);
-  chain.range  = jest.fn().mockReturnValue(chain);
-  chain.eq     = jest.fn().mockReturnValue(chain);
-  chain.gte    = jest.fn().mockReturnValue(chain);
-  chain.lte    = jest.fn().mockReturnValue(chain);
-  chain.ilike  = jest.fn().mockReturnValue(chain);
-  const resolvedPromise = Promise.resolve(result);
-  Object.defineProperty(chain, 'then', {
-    get: () => resolvedPromise.then.bind(resolvedPromise),
-  });
+
+  chain.sort = jest.fn().mockReturnValue(chain);
+  chain.skip = jest.fn().mockReturnValue(chain);
+  chain.limit = jest.fn().mockReturnValue(chain);
+  chain.populate = jest.fn().mockReturnValue(chain);
+  chain.lean = jest.fn().mockResolvedValue(result);
+
   return chain;
 }
 
-// ─── Fixtures ────────────────────────────────────────────────────────────────
+const ADMIN_AUTH = {
+  userId: 9,
+  roleId: 1,
+  roleName: 'admin',
+  isAuthenticated: true,
+  isAdmin: true,
+};
 
-const ADMIN_AUTH = { userId: 9, roleId: 1, roleName: 'admin', isAuthenticated: true,  isAdmin: true  };
-const USER_AUTH  = { userId: 7, roleId: 2, roleName: 'user',  isAuthenticated: true,  isAdmin: false };
-const ANON_AUTH  = { userId: null, roleId: null, roleName: null, isAuthenticated: false, isAdmin: false };
+const USER_AUTH = {
+  userId: 7,
+  roleId: 2,
+  roleName: 'user',
+  isAuthenticated: true,
+  isAdmin: false,
+};
+
+const ANON_AUTH = {
+  userId: null,
+  roleId: null,
+  roleName: null,
+  isAuthenticated: false,
+  isAdmin: false,
+};
 
 const MOCK_LOGS = [
-  { id: 1, level: 'info',  message: 'Request logged', source: 'middleware', timestamp: '2026-01-01T00:00:00.000Z' },
-  { id: 2, level: 'error', message: 'DB error',        source: 'api',        timestamp: '2026-01-01T00:01:00.000Z' },
+  {
+    _id: 'mongo-log-1',
+    legacy_id: '1',
+    level: 'info',
+    message: 'Request logged',
+    source: 'middleware',
+    timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    user_id: {
+      _id: 'mongo-user-42',
+      legacy_id: '42',
+    },
+  },
+  {
+    _id: 'mongo-log-2',
+    legacy_id: '2',
+    level: 'error',
+    message: 'DB error',
+    source: 'api',
+    timestamp: new Date('2026-01-01T00:01:00.000Z'),
+    user_id: null,
+  },
 ];
 
-// ─── Tests ────────────────────────────────────────────────────────────────────
-
 describe('GET /api/logs', () => {
+  let findChain: Record<string, jest.Mock>;
+  let userFindOneLean: jest.Mock;
+
   beforeEach(() => {
     jest.clearAllMocks();
+
     (getAuthUser as jest.Mock).mockReturnValue(ADMIN_AUTH);
-    (supabase.from as jest.Mock).mockReturnValue(
-      makeChain({ data: MOCK_LOGS, error: null, count: 2 }),
-    );
+    (dbConnect as jest.Mock).mockResolvedValue(undefined);
+
+    findChain = makeFindChain(MOCK_LOGS);
+    (Log.find as jest.Mock).mockReturnValue(findChain);
+    (Log.countDocuments as jest.Mock).mockResolvedValue(2);
+
+    userFindOneLean = jest.fn().mockResolvedValue(null);
+
+    (User.findOne as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: userFindOneLean,
+      }),
+    });
   });
 
-  test('unauthenticated request → 401', async () => {
+  test('returns 401 for an unauthenticated request', async () => {
     (getAuthUser as jest.Mock).mockReturnValue(ANON_AUTH);
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    expect(res.status).toBe(401);
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
     expect(body.success).toBe(false);
+    expect(dbConnect).not.toHaveBeenCalled();
   });
 
-  test('authenticated non-admin → 403', async () => {
+  test('returns 403 for an authenticated non-admin user', async () => {
     (getAuthUser as jest.Mock).mockReturnValue(USER_AUTH);
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    expect(res.status).toBe(403);
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
     expect(body.success).toBe(false);
+    expect(dbConnect).not.toHaveBeenCalled();
   });
 
-  test('admin → 200 with correct data and full pagination shape', async () => {
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    expect(res.status).toBe(200);
+  test('returns logs with the existing API and pagination shape', async () => {
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
     expect(body.success).toBe(true);
-    expect(body.data).toEqual(MOCK_LOGS);
+
+    expect(body.data).toEqual([
+      {
+        id: 1,
+        level: 'info',
+        message: 'Request logged',
+        source: 'middleware',
+        timestamp: new Date('2026-01-01T00:00:00.000Z'),
+        user_id: 42,
+      },
+      {
+        id: 2,
+        level: 'error',
+        message: 'DB error',
+        source: 'api',
+        timestamp: new Date('2026-01-01T00:01:00.000Z'),
+        user_id: null,
+      },
+    ]);
+
     expect(body.pagination).toEqual({
       page: 1,
       pageSize: 50,
@@ -116,33 +205,139 @@ describe('GET /api/logs', () => {
       hasNext: false,
       hasPrev: false,
     });
+
+    expect(dbConnect).toHaveBeenCalled();
   });
 
-  test('level filter → .eq("level", value) is applied to the query', async () => {
-    const chain = makeChain({ data: [MOCK_LOGS[1]], error: null, count: 1 });
-    (supabase.from as jest.Mock).mockReturnValue(chain);
-
-    const res = await GET(makeRequest('http://localhost:3000/api/logs?level=error'));
-    expect(res.status).toBe(200);
-    expect(chain.eq).toHaveBeenCalledWith('level', 'error');
-  });
-
-  test('user_id filter → .eq("user_id", integer) is applied to the query', async () => {
-    const chain = makeChain({ data: [MOCK_LOGS[0]], error: null, count: 1 });
-    (supabase.from as jest.Mock).mockReturnValue(chain);
-
-    const res = await GET(makeRequest('http://localhost:3000/api/logs?user_id=42'));
-    expect(res.status).toBe(200);
-    expect(chain.eq).toHaveBeenCalledWith('user_id', 42);
-  });
-
-  test('Supabase failure → 500 with success: false', async () => {
-    (supabase.from as jest.Mock).mockReturnValue(
-      makeChain({ data: null, error: { message: 'Connection refused' }, count: null }),
+  test('applies a level filter to the MongoDB query', async () => {
+    await GET(
+      makeRequest('http://localhost:3000/api/logs?level=error'),
     );
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    expect(res.status).toBe(500);
+
+    expect(Log.find).toHaveBeenCalledWith({
+      level: 'error',
+    });
+  });
+
+  test('maps a legacy user ID to its MongoDB ObjectId', async () => {
+    const mongoUserId = new Types.ObjectId();
+
+    userFindOneLean.mockResolvedValue({
+      _id: mongoUserId,
+    });
+
+    await GET(
+      makeRequest('http://localhost:3000/api/logs?user_id=42'),
+    );
+
+    expect(User.findOne).toHaveBeenCalledWith({
+      legacy_id: '42',
+    });
+
+    expect(Log.find).toHaveBeenCalledWith({
+      user_id: mongoUserId,
+    });
+  });
+
+  test('returns no matches when a legacy user ID cannot be resolved', async () => {
+    userFindOneLean.mockResolvedValue(null);
+
+    await GET(
+      makeRequest('http://localhost:3000/api/logs?user_id=99999'),
+    );
+
+    expect(Log.find).toHaveBeenCalledWith({
+      user_id: {
+        $in: [],
+      },
+    });
+  });
+
+  test('returns 500 when the MongoDB connection fails', async () => {
+    (dbConnect as jest.Mock).mockRejectedValue(
+      new Error('Connection refused'),
+    );
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.success).toBe(false);
+  });
+});
+
+describe('DELETE /api/logs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getAuthUser as jest.Mock).mockReturnValue(ADMIN_AUTH);
+    (dbConnect as jest.Mock).mockResolvedValue(undefined);
+    (Log.deleteMany as jest.Mock).mockResolvedValue({
+      deletedCount: 3,
+    });
+  });
+
+  test('returns 401 for an unauthenticated request', async () => {
+    (getAuthUser as jest.Mock).mockReturnValue(ANON_AUTH);
+
+    const response = await DELETE(
+      makeRequest(
+        'http://localhost:3000/api/logs?olderThanDays=30',
+      ),
+    );
+
+    expect(response.status).toBe(401);
+    expect(Log.deleteMany).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 when olderThanDays is invalid', async () => {
+    const response = await DELETE(
+      makeRequest(
+        'http://localhost:3000/api/logs?olderThanDays=0',
+      ),
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(Log.deleteMany).not.toHaveBeenCalled();
+  });
+
+  test('deletes logs older than the requested number of days', async () => {
+    const response = await DELETE(
+      makeRequest(
+        'http://localhost:3000/api/logs?olderThanDays=30',
+      ),
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.deleted).toBe(3);
+
+    expect(Log.deleteMany).toHaveBeenCalledWith({
+      timestamp: {
+        $lt: expect.any(Date),
+      },
+    });
+  });
+
+  test('returns 500 when MongoDB deletion fails', async () => {
+    (Log.deleteMany as jest.Mock).mockRejectedValue(
+      new Error('Delete failed'),
+    );
+
+    const response = await DELETE(
+      makeRequest(
+        'http://localhost:3000/api/logs?olderThanDays=30',
+      ),
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
     expect(body.success).toBe(false);
   });
 });

--- a/next_webapp/src/__tests__/utils/databaseTransport.test.ts
+++ b/next_webapp/src/__tests__/utils/databaseTransport.test.ts
@@ -1,39 +1,72 @@
 /**
  * @jest-environment node
  *
- * Tests for DatabaseTransport
- * Verifies that log entries are correctly shaped and inserted into Supabase,
- * that extra fields land in meta, and that insert failures do not throw.
+ * Tests for the MongoDB Winston database transport.
  */
 
-// ─── Mocks ──────────────────────────────────────────────────────────────────
-
-jest.mock('@/library/supabaseClient', () => ({
-  supabase: { from: jest.fn() },
+jest.mock('@/lib/dbConnect', () => ({
+  __esModule: true,
+  default: jest.fn(),
 }));
 
-// ─── Imports ─────────────────────────────────────────────────────────────────
+jest.mock('@/models/mongoose/Log', () => ({
+  __esModule: true,
+  default: {
+    insertMany: jest.fn(),
+  },
+}));
 
+jest.mock('@/models/mongoose/User', () => ({
+  __esModule: true,
+  default: {
+    find: jest.fn(),
+  },
+}));
+
+import { Types } from 'mongoose';
 import DatabaseTransport from '../../utils/databaseTransport';
-import { supabase } from '@/library/supabaseClient';
-
-// ─── Tests ───────────────────────────────────────────────────────────────────
+import dbConnect from '@/lib/dbConnect';
+import Log from '@/models/mongoose/Log';
+import User from '@/models/mongoose/User';
 
 describe('DatabaseTransport', () => {
   let transport: DatabaseTransport;
-  let mockInsert: jest.Mock;
+  let userLean: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+
     transport = new DatabaseTransport({ level: 'info' });
-    mockInsert = jest.fn().mockResolvedValue({ error: null });
-    (supabase.from as jest.Mock).mockReturnValue({ insert: mockInsert });
+
+    (dbConnect as jest.Mock).mockResolvedValue(undefined);
+    (Log.insertMany as jest.Mock).mockResolvedValue([]);
+
+    userLean = jest.fn().mockResolvedValue([]);
+
+    (User.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: userLean,
+      }),
+    });
   });
 
-  test('inserts a row with the correct standard fields', async () => {
+  afterEach(() => {
+    transport.close();
+  });
+
+  test('writes a correctly shaped log batch to MongoDB', async () => {
+    const mongoUserId = new Types.ObjectId();
+
+    userLean.mockResolvedValue([
+      {
+        _id: mongoUserId,
+        legacy_id: '42',
+      },
+    ]);
+
     const callback = jest.fn();
 
-    await transport.log(
+    transport.log(
       {
         level: 'info',
         message: 'User logged in',
@@ -46,75 +79,139 @@ describe('DatabaseTransport', () => {
       callback,
     );
 
-    expect(supabase.from).toHaveBeenCalledWith('logs');
-    expect(mockInsert).toHaveBeenCalledWith([
-      expect.objectContaining({
-        level: 'info',
-        message: 'User logged in',
-        source: 'api',
-        user_id: 42,
-        method: 'POST',
-        url: '/api/auth/login',
-        status_code: 200,
-        timestamp: expect.any(String),
-      }),
-    ]);
+    await transport.flush();
+
     expect(callback).toHaveBeenCalled();
+    expect(dbConnect).toHaveBeenCalled();
+
+    expect(User.find).toHaveBeenCalledWith({
+      legacy_id: { $in: ['42'] },
+    });
+
+    expect(Log.insertMany).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          level: 'info',
+          message: 'User logged in',
+          source: 'api',
+          user_id: mongoUserId,
+          method: 'POST',
+          url: '/api/auth/login',
+          status_code: 200,
+          timestamp: expect.any(Date),
+        }),
+      ],
+      { ordered: false },
+    );
   });
 
-  test('captures unknown fields (e.g. error_code) in meta and does not drop them', async () => {
+  test('removes ANSI colour codes before writing logs', async () => {
     const callback = jest.fn();
 
-    await transport.log(
+    transport.log(
+      {
+        level: '\u001b[32minfo\u001b[39m',
+        message: '\u001b[31mDatabase error\u001b[39m',
+        source: 'api',
+      },
+      callback,
+    );
+
+    await transport.flush();
+
+    expect(Log.insertMany).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          level: 'info',
+          message: 'Database error',
+        }),
+      ],
+      { ordered: false },
+    );
+  });
+
+  test('stores unknown fields inside meta', async () => {
+    const callback = jest.fn();
+
+    transport.log(
       {
         level: 'error',
         message: 'Login failed',
         source: 'api',
-        status_code: 401,
         error_code: 'INVALID_CREDENTIALS',
       },
       callback,
     );
 
-    expect(mockInsert).toHaveBeenCalledWith([
-      expect.objectContaining({
-        meta: { error_code: 'INVALID_CREDENTIALS' },
-      }),
-    ]);
-    expect(callback).toHaveBeenCalled();
+    await transport.flush();
+
+    expect(Log.insertMany).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          meta: {
+            error_code: 'INVALID_CREDENTIALS',
+          },
+        }),
+      ],
+      { ordered: false },
+    );
   });
 
-  test('meta is empty object when all provided fields are standard columns', async () => {
+  test('accepts an existing MongoDB ObjectId without a user lookup', async () => {
+    const mongoUserId = new Types.ObjectId().toString();
     const callback = jest.fn();
 
-    await transport.log(
+    transport.log(
       {
         level: 'info',
-        message: 'Request received',
-        source: 'middleware',
-        user_id: 1,
-        method: 'GET',
-        url: '/api/profile',
+        message: 'MongoDB user request',
+        user_id: mongoUserId,
       },
       callback,
     );
 
-    expect(mockInsert).toHaveBeenCalledWith([
-      expect.objectContaining({ meta: {} }),
-    ]);
+    await transport.flush();
+
+    expect(User.find).not.toHaveBeenCalled();
+
+    expect(Log.insertMany).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          user_id: mongoUserId,
+        }),
+      ],
+      { ordered: false },
+    );
   });
 
-  test('Supabase insert failure is caught and console.error-ed without throwing', async () => {
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    mockInsert.mockResolvedValue({ error: { message: 'Connection refused' } });
+  test('catches MongoDB insert failures without throwing', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => { });
+
+    (Log.insertMany as jest.Mock).mockRejectedValue(
+      new Error('Connection refused'),
+    );
+
     const callback = jest.fn();
 
-    await transport.log({ level: 'error', message: 'something failed' }, callback);
+    transport.log(
+      {
+        level: 'error',
+        message: 'Something failed',
+      },
+      callback,
+    );
+
+    await expect(transport.flush()).resolves.toBeUndefined();
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Failed to insert log into database:',
-      expect.objectContaining({ message: 'Connection refused' }),
+      'Database transport flush error:',
+      expect.objectContaining({
+        message: 'Connection refused',
+      }),
     );
+
     expect(callback).toHaveBeenCalled();
 
     consoleErrorSpy.mockRestore();

--- a/next_webapp/src/app/api/logs/route.ts
+++ b/next_webapp/src/app/api/logs/route.ts
@@ -1,117 +1,245 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/library/supabaseClient';
+import { Types } from 'mongoose';
+import dbConnect from '@/lib/dbConnect';
+import Log from '@/models/mongoose/Log';
+import User from '@/models/mongoose/User';
 import { getAuthUser } from '@/app/api/library/auth';
 import logger from '@/utils/logger';
 
+const ALLOWED_SORT = new Set([
+  'timestamp',
+  'level',
+  'source',
+  'method',
+  'status_code',
+  'response_time',
+]);
+
+function parsePositiveInteger(
+  value: string | null,
+  fallback: number,
+): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeLegacyId(value: unknown): string | number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const text = String(value);
+  const numberValue = Number(text);
+
+  return Number.isSafeInteger(numberValue) && String(numberValue) === text
+    ? numberValue
+    : text;
+}
+
+function getResponseUserId(user: any): string | number | null {
+  if (!user) {
+    return null;
+  }
+
+  if (typeof user === 'object' && user.legacy_id) {
+    return normalizeLegacyId(user.legacy_id);
+  }
+
+  if (typeof user === 'object' && user._id) {
+    return String(user._id);
+  }
+
+  return String(user);
+}
+
+function toLogDTO(log: any) {
+  const {
+    _id,
+    __v,
+    legacy_id: legacyId,
+    user_id: userId,
+    ...logData
+  } = log;
+
+  return {
+    id: normalizeLegacyId(legacyId) ?? String(_id),
+    ...logData,
+    user_id: getResponseUserId(userId),
+  };
+}
+
+// GET /api/logs
+// Returns paginated logs for admin users.
 export async function GET(request: NextRequest) {
   try {
-    // Check admin authorization
-    const { isAuthenticated, isAdmin } = getAuthUser(request);
+    const authUser = getAuthUser(request);
 
-    if (!isAuthenticated) {
+    if (!authUser.isAuthenticated) {
       logger.warn('Unauthorized access attempt to logs API', {
         source: 'api',
         url: '/api/logs',
-        ip_address: request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown',
+        ip_address:
+          request.headers.get('x-forwarded-for') ||
+          request.headers.get('x-real-ip') ||
+          'unknown',
       });
+
       return NextResponse.json(
         { success: false, message: 'Unauthorized' },
-        { status: 401 }
+        { status: 401 },
       );
     }
 
-    if (!isAdmin) {
+    if (!authUser.isAdmin) {
       logger.warn('Non-admin access attempt to logs API', {
         source: 'api',
         url: '/api/logs',
-        ip_address: request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown',
+        ip_address:
+          request.headers.get('x-forwarded-for') ||
+          request.headers.get('x-real-ip') ||
+          'unknown',
       });
+
       return NextResponse.json(
         { success: false, message: 'Forbidden - Admin only' },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
-    // Parse query parameters
     const url = new URL(request.url);
-    const page = parseInt(url.searchParams.get('page') || '1');
-    const pageSize = parseInt(url.searchParams.get('pageSize') || '50');
-    const level = url.searchParams.get('level'); // error, warn, info, etc.
-    const source = url.searchParams.get('source'); // middleware, api, etc.
+
+    const page = parsePositiveInteger(url.searchParams.get('page'), 1);
+    const pageSize = Math.min(
+      parsePositiveInteger(url.searchParams.get('pageSize'), 50),
+      200,
+    );
+
+    const level = url.searchParams.get('level');
+    const source = url.searchParams.get('source');
     const startDate = url.searchParams.get('startDate');
     const endDate = url.searchParams.get('endDate');
-    const search = url.searchParams.get('search'); // Search in message
-    const userId = parseInt(url.searchParams.get('user_id') ?? '');
+    const search = url.searchParams.get('search');
+    const rawUserId = url.searchParams.get('user_id');
 
-    const ALLOWED_SORT = new Set(['timestamp', 'level', 'source', 'method', 'status_code', 'response_time']);
     const rawSortBy = url.searchParams.get('sortBy') ?? 'timestamp';
     const rawSortOrder = url.searchParams.get('sortOrder') ?? 'desc';
-    const sortBy = ALLOWED_SORT.has(rawSortBy) ? rawSortBy : 'timestamp';
-    const ascending = rawSortOrder.toLowerCase() === 'asc';
 
-    // Calculate offset
-    const offset = (page - 1) * pageSize;
+    const sortBy = ALLOWED_SORT.has(rawSortBy)
+      ? rawSortBy
+      : 'timestamp';
 
-    // Build query
-    let query = supabase
-      .from('logs')
-      .select('*', { count: 'exact' })
-      .order(sortBy, { ascending })
-      .range(offset, offset + pageSize - 1);
+    const sortDirection: 1 | -1 =
+      rawSortOrder.toLowerCase() === 'asc' ? 1 : -1;
 
-    // Apply filters
+    const filter: Record<string, unknown> = {};
+
     if (level) {
-      query = query.eq('level', level);
+      filter.level = level;
     }
 
     if (source) {
-      query = query.eq('source', source);
-    }
-
-    if (!Number.isNaN(userId)) {
-      query = query.eq('user_id', userId);
-    }
-
-    if (startDate) {
-      query = query.gte('timestamp', startDate);
-    }
-
-    if (endDate) {
-      query = query.lte('timestamp', endDate);
+      filter.source = source;
     }
 
     if (search) {
-      query = query.ilike('message', `%${search}%`);
+      filter.message = {
+        $regex: escapeRegex(search),
+        $options: 'i',
+      };
     }
 
-    // Execute query
-    const { data, error, count } = await query;
+    const timestampFilter: {
+      $gte?: Date;
+      $lte?: Date;
+    } = {};
 
-    if (error) {
-      logger.error(`Database error fetching logs: ${error.message}`, {
-        source: 'api',
-        url: '/api/logs',
-        error: error.message,
-      });
-      return NextResponse.json(
-        { success: false, message: 'Failed to fetch logs' },
-        { status: 500 }
-      );
+    if (startDate) {
+      const parsedStartDate = new Date(startDate);
+
+      if (Number.isNaN(parsedStartDate.getTime())) {
+        return NextResponse.json(
+          { success: false, message: 'Invalid startDate' },
+          { status: 400 },
+        );
+      }
+
+      timestampFilter.$gte = parsedStartDate;
     }
 
-    const total = count || 0;
+    if (endDate) {
+      const parsedEndDate = new Date(endDate);
+
+      if (Number.isNaN(parsedEndDate.getTime())) {
+        return NextResponse.json(
+          { success: false, message: 'Invalid endDate' },
+          { status: 400 },
+        );
+      }
+
+      timestampFilter.$lte = parsedEndDate;
+    }
+
+    if (Object.keys(timestampFilter).length > 0) {
+      filter.timestamp = timestampFilter;
+    }
+
+    await dbConnect();
+
+    if (rawUserId) {
+      if (/^[0-9a-fA-F]{24}$/.test(rawUserId)) {
+        filter.user_id = new Types.ObjectId(rawUserId);
+      } else {
+        const user = await User.findOne({
+          legacy_id: rawUserId,
+        })
+          .select('_id')
+          .lean();
+
+        // An empty $in condition safely returns no matching logs.
+        filter.user_id = user?._id ?? { $in: [] };
+      }
+    }
+
+    const offset = (page - 1) * pageSize;
+
+    const [logs, total] = await Promise.all([
+      Log.find(filter)
+        .sort({ [sortBy]: sortDirection })
+        .skip(offset)
+        .limit(pageSize)
+        .populate({
+          path: 'user_id',
+          select: 'legacy_id',
+        })
+        .lean(),
+      Log.countDocuments(filter),
+    ]);
+
     const totalPages = Math.ceil(total / pageSize);
 
     logger.info('Admin accessed logs API', {
       source: 'api',
       url: '/api/logs',
-      user_id: getAuthUser(request).userId,
-      filters: { page, pageSize, level, source, startDate, endDate, search, user_id: !Number.isNaN(userId) ? userId : undefined },
+      user_id: authUser.userId,
+      filters: {
+        page,
+        pageSize,
+        level,
+        source,
+        startDate,
+        endDate,
+        search,
+        user_id: rawUserId ?? undefined,
+      },
     });
 
     return NextResponse.json({
       success: true,
-      data,
+      data: logs.map(toLogDTO),
       pagination: {
         page,
         pageSize,
@@ -121,68 +249,96 @@ export async function GET(request: NextRequest) {
         hasPrev: page > 1,
       },
     });
-
   } catch (error) {
-    logger.error(`Unexpected error in logs API: ${error instanceof Error ? error.message : String(error)}`, {
-      source: 'api',
-      url: '/api/logs',
-    });
+    logger.error(
+      `Unexpected error in logs API: ${error instanceof Error ? error.message : String(error)
+      }`,
+      {
+        source: 'api',
+        url: '/api/logs',
+      },
+    );
+
     return NextResponse.json(
       { success: false, message: 'Internal Server Error' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
-// DELETE /api/logs?olderThanDays=N  — log retention purge (admin only)
+// DELETE /api/logs?olderThanDays=N
+// Deletes logs older than the requested number of days.
 export async function DELETE(request: NextRequest) {
   try {
-    const { isAuthenticated, isAdmin } = getAuthUser(request);
+    const authUser = getAuthUser(request);
 
-    if (!isAuthenticated) {
-      return NextResponse.json({ success: false, message: 'Unauthorized' }, { status: 401 });
-    }
-    if (!isAdmin) {
-      return NextResponse.json({ success: false, message: 'Forbidden - Admin only' }, { status: 403 });
-    }
-
-    const url = new URL(request.url);
-    const rawDays = parseInt(url.searchParams.get('olderThanDays') || '');
-    if (isNaN(rawDays) || rawDays < 1) {
+    if (!authUser.isAuthenticated) {
       return NextResponse.json(
-        { success: false, message: 'olderThanDays must be a positive integer' },
-        { status: 400 }
+        { success: false, message: 'Unauthorized' },
+        { status: 401 },
       );
     }
 
-    const cutoff = new Date(Date.now() - rawDays * 86_400_000).toISOString();
-
-    const { error, count } = await supabase
-      .from('logs')
-      .delete({ count: 'exact' })
-      .lt('timestamp', cutoff);
-
-    if (error) {
-      logger.error(`Log retention purge failed: ${error.message}`, { source: 'api', url: '/api/logs' });
-      return NextResponse.json({ success: false, message: 'Failed to purge logs' }, { status: 500 });
+    if (!authUser.isAdmin) {
+      return NextResponse.json(
+        { success: false, message: 'Forbidden - Admin only' },
+        { status: 403 },
+      );
     }
 
-    logger.info(`Log retention: purged ${count ?? 0} rows older than ${rawDays} days`, {
-      source: 'api',
-      url: '/api/logs',
-      user_id: getAuthUser(request).userId,
+    const url = new URL(request.url);
+    const rawDays = Number.parseInt(
+      url.searchParams.get('olderThanDays') ?? '',
+      10,
+    );
+
+    if (!Number.isInteger(rawDays) || rawDays < 1) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'olderThanDays must be a positive integer',
+        },
+        { status: 400 },
+      );
+    }
+
+    const cutoff = new Date(Date.now() - rawDays * 86_400_000);
+
+    await dbConnect();
+
+    const result = await Log.deleteMany({
+      timestamp: { $lt: cutoff },
     });
+
+    const deletedCount = result.deletedCount ?? 0;
+
+    logger.info(
+      `Log retention: purged ${deletedCount} rows older than ${rawDays} days`,
+      {
+        source: 'api',
+        url: '/api/logs',
+        user_id: authUser.userId,
+      },
+    );
 
     return NextResponse.json({
       success: true,
-      message: `Deleted ${count ?? 0} log entries older than ${rawDays} days`,
-      deleted: count ?? 0,
+      message: `Deleted ${deletedCount} log entries older than ${rawDays} days`,
+      deleted: deletedCount,
     });
   } catch (error) {
-    logger.error(`Unexpected error in log purge: ${error instanceof Error ? error.message : String(error)}`, {
-      source: 'api',
-      url: '/api/logs',
-    });
-    return NextResponse.json({ success: false, message: 'Internal Server Error' }, { status: 500 });
+    logger.error(
+      `Unexpected error in log purge: ${error instanceof Error ? error.message : String(error)
+      }`,
+      {
+        source: 'api',
+        url: '/api/logs',
+      },
+    );
+
+    return NextResponse.json(
+      { success: false, message: 'Internal Server Error' },
+      { status: 500 },
+    );
   }
 }

--- a/next_webapp/src/utils/databaseTransport.ts
+++ b/next_webapp/src/utils/databaseTransport.ts
@@ -1,13 +1,16 @@
 import winston from 'winston';
-import { supabase } from '@/library/supabaseClient';
+import { Types } from 'mongoose';
+import dbConnect from '@/lib/dbConnect';
+import Log from '@/models/mongoose/Log';
+import User from '@/models/mongoose/User';
 
 interface LogEntry {
   level: string;
   message: string;
-  timestamp: string;
-  meta?: any;
+  timestamp: Date;
+  meta?: Record<string, unknown>;
   source?: string;
-  user_id?: number;
+  user_id?: number | string | null;
   ip_address?: string | null;
   user_agent?: string;
   method?: string;
@@ -17,45 +20,75 @@ interface LogEntry {
 }
 
 const KNOWN_FIELDS = new Set<string | symbol>([
-  'level', 'message', 'source', 'user_id', 'ip_address', 'user_agent',
-  'method', 'url', 'status_code', 'response_time',
-  'timestamp', 'splat', 'service', Symbol.for('level'), Symbol.for('splat'),
+  'level',
+  'message',
+  'source',
+  'user_id',
+  'ip_address',
+  'user_agent',
+  'method',
+  'url',
+  'status_code',
+  'response_time',
+  'timestamp',
+  'splat',
+  'service',
+  Symbol.for('level'),
+  Symbol.for('splat'),
 ]);
 
-const FLUSH_INTERVAL_MS = 10_000; // flush every 10 seconds
-const FLUSH_BATCH_SIZE = 20;      // flush early if buffer reaches 20 entries
+const FLUSH_INTERVAL_MS = 10_000;
+const FLUSH_BATCH_SIZE = 20;
+
+// Removes Winston colour codes before logs are written to MongoDB.
+const ANSI_ESCAPE_PATTERN =
+  /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+
+function removeAnsi(value: unknown): string {
+  return String(value ?? '').replace(ANSI_ESCAPE_PATTERN, '');
+}
 
 class DatabaseTransport extends winston.Transport {
   private buffer: LogEntry[] = [];
   private flushTimer: ReturnType<typeof setInterval> | null = null;
+  private isFlushing = false;
 
   constructor(opts?: any) {
     super(opts);
-    this.flushTimer = setInterval(() => this.flush(), FLUSH_INTERVAL_MS);
-    // Allow the process to exit without waiting for the timer
-    if (this.flushTimer.unref) this.flushTimer.unref();
+
+    this.flushTimer = setInterval(() => {
+      void this.flush();
+    }, FLUSH_INTERVAL_MS);
+
+    if (this.flushTimer.unref) {
+      this.flushTimer.unref();
+    }
   }
 
   log(info: any, callback: () => void) {
     const meta: Record<string, unknown> = {};
+
     for (const key of Object.keys(info)) {
       if (!KNOWN_FIELDS.has(key)) {
-        meta[key] = (info as Record<string, unknown>)[key];
+        meta[key] = info[key];
       }
     }
 
-    const rawIp: string | undefined = info.ip_address;
-    const validIp = rawIp && /^[\d.:a-fA-F]+$/.test(rawIp.split(',')[0].trim())
-      ? rawIp.split(',')[0].trim()
-      : null;
+    const rawIp =
+      typeof info.ip_address === 'string' ? info.ip_address : undefined;
+
+    const firstIp = rawIp?.split(',')[0].trim();
+
+    const validIp =
+      firstIp && /^[\d.:a-fA-F]+$/.test(firstIp) ? firstIp : null;
 
     this.buffer.push({
-      level: info.level,
-      message: info.message,
-      timestamp: new Date().toISOString(),
+      level: removeAnsi(info.level),
+      message: removeAnsi(info.message),
+      timestamp: new Date(),
       meta: Object.keys(meta).length ? meta : undefined,
       source: info.source || 'application',
-      user_id: info.user_id,
+      user_id: info.user_id ?? null,
       ip_address: validIp,
       user_agent: info.user_agent,
       method: info.method,
@@ -65,21 +98,86 @@ class DatabaseTransport extends winston.Transport {
     });
 
     if (this.buffer.length >= FLUSH_BATCH_SIZE) {
-      this.flush();
+      void this.flush();
     }
 
     callback();
   }
 
-  private async flush() {
-    if (this.buffer.length === 0) return;
+  async flush(): Promise<void> {
+    if (this.isFlushing || this.buffer.length === 0) {
+      return;
+    }
+
+    this.isFlushing = true;
     const batch = this.buffer.splice(0, this.buffer.length);
+
     try {
-      const { error } = await supabase.from('logs').insert(batch);
-      if (error) console.error('Failed to insert log batch into database:', error);
+      await dbConnect();
+
+      const legacyUserIds = Array.from(
+        new Set(
+          batch
+            .map((entry) => entry.user_id)
+            .filter(
+              (userId): userId is number | string =>
+                userId !== null && userId !== undefined,
+            )
+            .map(String)
+            .filter((userId) => !Types.ObjectId.isValid(userId)),
+        ),
+      );
+
+      const userIdMap = new Map<string, unknown>();
+
+      if (legacyUserIds.length > 0) {
+        const users = await User.find({
+          legacy_id: { $in: legacyUserIds },
+        })
+          .select('_id legacy_id')
+          .lean();
+
+        for (const user of users) {
+          if (user.legacy_id) {
+            userIdMap.set(user.legacy_id, user._id);
+          }
+        }
+      }
+
+      const documents = batch.map((entry) => {
+        const { user_id: userId, ...logData } = entry;
+        const userIdString =
+          userId !== null && userId !== undefined ? String(userId) : null;
+
+        let mongoUserId: unknown = null;
+
+        if (userIdString) {
+          mongoUserId = Types.ObjectId.isValid(userIdString)
+            ? userIdString
+            : userIdMap.get(userIdString) ?? null;
+        }
+
+        return {
+          ...logData,
+          user_id: mongoUserId,
+        };
+      });
+
+      await Log.insertMany(documents, { ordered: false });
     } catch (error) {
       console.error('Database transport flush error:', error);
+    } finally {
+      this.isFlushing = false;
     }
+  }
+
+  close() {
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+
+    void this.flush();
   }
 }
 

--- a/next_webapp/src/utils/logger.ts
+++ b/next_webapp/src/utils/logger.ts
@@ -1,5 +1,4 @@
 import winston from 'winston';
-import DatabaseTransport from './databaseTransport';
 
 const levels = {
   error: 0,
@@ -19,7 +18,16 @@ const colors = {
 
 winston.addColors(colors);
 
-const format = winston.format.combine(
+// Clean format for database and file logs.
+const cleanFormat = winston.format.combine(
+  winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss:ms' }),
+  winston.format.printf(
+    (info) => `${info.timestamp} ${info.level}: ${info.message}`,
+  ),
+);
+
+// Colour is applied only to console output.
+const consoleFormat = winston.format.combine(
   winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss:ms' }),
   winston.format.colorize({ all: true }),
   winston.format.printf(
@@ -30,25 +38,35 @@ const format = winston.format.combine(
 const transports: winston.transport[] = [
   new winston.transports.Console({
     level: process.env.NODE_ENV === 'production' ? 'error' : 'debug',
-  }),
-  new DatabaseTransport({
-    level: 'info',
+    format: consoleFormat,
   }),
 ];
 
-// File transports need Node.js `path` and `fs` — not available in Edge Runtime.
-// `process.env.NEXT_RUNTIME` is replaced at build time, so webpack dead-code-eliminates
-// this entire block (including the require) from the Edge bundle.
+// MongoDB and file transports require the Node runtime.
+// Edge middleware keeps console logging only.
 if (process.env.NEXT_RUNTIME !== 'edge') {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const DatabaseTransport = require('./databaseTransport').default;
+
+  transports.push(
+    new DatabaseTransport({
+      level: 'info',
+      format: cleanFormat,
+    }),
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const nodePath = require('path') as typeof import('path');
+
   transports.push(
     new winston.transports.File({
       filename: nodePath.join(process.cwd(), 'logs', 'error.log'),
       level: 'error',
+      format: cleanFormat,
     }),
     new winston.transports.File({
       filename: nodePath.join(process.cwd(), 'logs', 'all.log'),
+      format: cleanFormat,
     }),
   );
 }
@@ -56,7 +74,6 @@ if (process.env.NEXT_RUNTIME !== 'edge') {
 const logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',
   levels,
-  format,
   transports,
 });
 


### PR DESCRIPTION
## Summary

Migrates the complete logging path from Supabase to MongoDB, including the `/api/logs` routes, Winston database transport, and related unit tests.

## Changes

* Migrated `GET /api/logs` to the verified Mongoose `Log` model.
* Preserved admin authorization, filtering, search, sorting, pagination, and the existing response structure.
* Migrated the retention DELETE route to `Log.deleteMany()`.
* Replaced Supabase batch inserts with MongoDB `insertMany()`.
* Mapped legacy numeric user IDs to MongoDB ObjectIds through `User.legacy_id`.
* Loaded the MongoDB transport only in the Node runtime; Edge middleware remains console-only.
* Prevented concurrent batch flushes.
* Removed Winston ANSI colour codes from new `level` and `message` values before insertion.
* Updated route and database transport unit tests for MongoDB.

## Testing

* `16/16` logging tests passed.
* `2/2` targeted test suites passed.
* Production build completed successfully.
* `/api/logs` and middleware compiled successfully after rebasing onto the latest `master`.

## Notes

* Uses the existing verified `Log` and `User` Mongoose models.
* No database schema or TTL index changes were made.
* Existing logs containing ANSI codes were not backfilled; they will expire through the existing 90-day TTL policy.
* The build still reports the project’s existing ESLint option compatibility warning, but compilation and page generation complete successfully.
