### PR TITLE
Refactor: unify global CSS font and fix dark mode stability

### DIFF
--- a/next_webapp/src/app/[locale]/globals.css
+++ b/next_webapp/src/app/[locale]/globals.css
@@ -15,20 +15,17 @@
 @layer base {
   html {
     font-family: "Poppins", sans-serif;
+  }
+
+  body {
     color: var(--color-dark);
     background: var(--color-light);
   }
-}
-/* Uncomment above when dark mode is implemented */
 
-body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+  .dark body {
+    color: var(--color-light);
+    background: var(--color-dark);
+  }
 }
 
 @layer utilities {

--- a/next_webapp/src/app/[locale]/layout.tsx
+++ b/next_webapp/src/app/[locale]/layout.tsx
@@ -1,10 +1,7 @@
-import { Inter } from "next/font/google";
 import "./globals.css";
 
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export default async function LocaleLayout({
   children,
@@ -18,9 +15,27 @@ export default async function LocaleLayout({
 
   return (
     <html lang={locale} suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function () {
+                try {
+                  var stored = localStorage.getItem("theme");
+                  if (stored === "dark") {
+                    document.documentElement.classList.add("dark");
+                  } else {
+                    document.documentElement.classList.remove("dark");
+                  }
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
+      </head>
       <body
         suppressHydrationWarning
-        className={`${inter.className} min-h-screen flex flex-col`}
+        className="min-h-screen flex flex-col"
       >
         <NextIntlClientProvider messages={messages}>
           <div className="flex-1 flex flex-col">{children}</div>


### PR DESCRIPTION
## Summary
Establishes a unified global CSS foundation and fixes dark mode inconsistencies across the About, Login, and Privacy pages.

## Changes
- **tailwind.config.ts**: No change needed — `darkMode: 'class'` was already configured correctly.
- **layout.tsx**: Removed the conflicting `Inter` font import/usage. Poppins (already set in globals.css and tailwind.config.ts) is now the single active font project-wide.
- **globals.css**: Removed the body background rule referencing undefined `--foreground-rgb` / `--background-*-rgb` variables, which caused a translucent backdrop. Replaced with the project's actual `--color-dark` / `--color-light` variables, plus a new `.dark body` rule.

## Bug found during testing
Dark mode toggle logic previously lived only in the Privacy page's local state + localStorage effect. About and Login had `dark:` classes defined but no way to activate them on a fresh page load — dark mode only appeared to work on those pages after client-side navigation from Privacy. Fixed by adding a blocking inline script in `layout.tsx`'s `<head>` that reads the same localStorage `"theme"` key on every page load, before paint.

## Testing
Verified locally:
- About, Login, and Privacy pages render a solid background (no translucent artifacts) in light mode
- Poppins is the only font active across all three pages
- Dark mode toggle on Privacy page still works and now persists correctly on a hard refresh of About/Login
- No console errors on any of the three pages

## Acceptance criteria
- [x] `tailwind.config.ts` contains a defined dark mode strategy
- [x] Only one primary font family is imported and active across the entire application
- [x] The body background renders a solid color without referencing missing RGB variables