### PR TITLE
WD: resolve duplicate locale in Back to use cases button href

### DIFF
--- a/next_webapp/src/app/[locale]/usecases/[id]/page.tsx
+++ b/next_webapp/src/app/[locale]/usecases/[id]/page.tsx
@@ -172,7 +172,7 @@ const UseCasePage: React.FC = () => {
           )}
 
           <Link
-            href="/en/usecases"
+            href="/usecases"
             className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-green-600 shadow-sm transition hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600"
           >
             <ArrowLeft size={16} />


### PR DESCRIPTION
 Description
Fixes a routing bug on the Use Case detail page (usecases/[id]/page.tsx) where clicking "Back to use cases" resulted in a 404 Page Not Found error.

🛠️ Root Cause & Fix
Root Cause: The button used href="/en/usecases" with @/i18n-navigation's Link component. Because next-intl automatically attaches the locale prefix (/en) to all internal routes, it generated /en/en/usecases (duplicate locale), causing a 404.
Fix: Updated href="/en/usecases" to href="/usecases" so next-intl correctly resolves the URL to /en/usecases.
🧪 Testing
Navigated to a Use Case detail page (/en/usecases/[id]) and clicked "Back to use cases".
Confirmed it now successfully returns to /en/usecases without any 404 errors.
<img width="940" height="543" alt="image" src="https://github.com/user-attachments/assets/079318a8-6277-4ac6-9c67-a1f8b26eb279" />
<img width="2540" height="1308" alt="image" src="https://github.com/user-attachments/assets/13ee2570-f849-4a6b-bddc-99ff0354b292" />
