### PR TITLE
WD: Fix/auth getauthuser objectid

### DIFF
--- a/next_webapp/src/app/api/library/auth.ts
+++ b/next_webapp/src/app/api/library/auth.ts
@@ -5,7 +5,7 @@ export function getAuthUser(request: NextRequest) {
   const roleIdRaw = request.headers.get("x-user-role-id");
   const roleName = request.headers.get("x-user-role");
 
-  const userId = userIdRaw ? Number(userIdRaw) : null;
+  const userId = userIdRaw && userIdRaw.trim() !== "" ? userIdRaw : null;
   const roleId = roleIdRaw ? Number(roleIdRaw) : null;
 
   return {

--- a/next_webapp/src/app/api/usecases/route.js
+++ b/next_webapp/src/app/api/usecases/route.js
@@ -36,7 +36,7 @@ export async function POST(request) {
   let uploadedFileId = null;
 
   try {
-    const { isAuthenticated, isAdmin } = getAuthUser(request);
+    const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
     if (!isAuthenticated) {
       return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request);
     }
@@ -54,14 +54,13 @@ export async function POST(request) {
       throw error;
     }
 
-    const { title, description, cover_img, category_id, created_by, tags, content } =
-      body;
+    // created_by is intentionally NOT read from the body it's stamped from
+    // the authenticated admin's own id below. A client-supplied creator id
+    // is never trusted (would let one admin attribute a use case to anyone).
+    const { title, description, cover_img, category_id, tags, content } = body;
 
     if (typeof title !== "string" || title.trim().length === 0) {
       return errorResponse("title is required", 400, "MISSING_FIELDS", request);
-    }
-    if (created_by === undefined || created_by === null || created_by === "") {
-      return errorResponse("created_by is required", 400, "MISSING_FIELDS", request);
     }
 
     // content is optional — a use case can be created without a notebook,
@@ -81,11 +80,11 @@ export async function POST(request) {
     await dbConnect();
 
     // Resolve category/tags/created_by (pure Mongo reads + tag upserts)
-    // before touching GridFS — if any of these throw, nothing has been
+    // before touching GridFS if any of these throw, nothing has been
     // uploaded yet, so there's nothing to clean up.
     const [categoryRef, createdByRef, tagRefs] = await Promise.all([
       resolveCategoryRef(category_id),
-      resolveCreatedBy(created_by),
+      resolveCreatedBy(userId),
       resolveTagRefs(tags),
     ]);
 


### PR DESCRIPTION
Fixes two bugs that were completely blocking admin actions across the whole app, logged-in admins were getting `401 User not authenticated` on every admin-protected route (use cases, contributors, categories). Both trace back to the recent auth migration leaving part of the old Postgres-era contract in place.

Bug 1 shared auth helper rejects all admins (the big one)

`getAuthUser()` in `src/app/api/library/auth.ts` was running `Number()` on the `x-user-id` header to check authentication. Since the auth migration (PR that moved login/signup/session to MongoDB), that header carries a **Mongo ObjectId string** , not a numeric Postgres id. `Number` is `NaN`, so `isAuthenticated` was always `false`, so every request through this shared helper was rejected as unauthenticated, before the admin check even ran.

Because this one helper is shared, it broke admin auth on use cases, contributors, and categories at the same time.

**Fix:** treat `x-user-id` as the string it now is (kept as-is for downstream `findById`, which wants the string anyway). The `roleId`/`isAdmin` logic is unchanged that side was never broken.

Bug 2 use-case create rejected `created_by`

With auth fixed, creating a use case then failed with `400 created_by is required`. The create route was expecting `created_by` in the request body, but the form no longer sends a valid one.

**Fix:** the route now stamps `created_by` from the authenticated admin's own id (server-side), instead of trusting the client to supply it. This is both correct and more secure, a client can no longer attribute a use case to another user.

Files changed

- `src/app/api/library/auth.ts`  treat `x-user-id` as an ObjectId string, not a number.
- `src/app/api/usecases/route.js`  set `created_by` from the authenticated session, not the request body.