### PR TITLE
WD: Fix Profile dark/light mode synchronization

### DIFF
--- a/next_webapp/src/app/[locale]/profile/page.jsx
+++ b/next_webapp/src/app/[locale]/profile/page.jsx
@@ -10,7 +10,6 @@ const Profile = () => {
   const router = useRouter();
   const params = useParams();
   const locale = params?.locale || "en";
-  const [darkMode, setDarkMode] = useState(false);
   const [profileImage, setProfileImage] = useState(null);
   const [formData, setFormData] = useState({
     first_name: "",
@@ -27,11 +26,6 @@ const Profile = () => {
   const [loading, setLoading] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
   const [fetchingProfile, setFetchingProfile] = useState(true);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    darkMode ? root.classList.add("dark") : root.classList.remove("dark");
-  }, [darkMode]);
 
   useEffect(() => {
     const token = localStorage.getItem("token");


### PR DESCRIPTION
## Summary

Fixes the Profile page theme synchronization issue where the page could become inconsistent with the site's selected dark/light mode.

## Changes

- Removed the Profile page's independent `darkMode` state.
- Removed the local effect that directly added/removed the `dark` class.
- Profile now follows the application's existing global theme state.

## Testing

- Tested the Profile page in dark mode.
- Navigated away from Profile and returned; dark mode remained consistent.
- Tested the same behaviour in light mode.
- Confirmed the Profile page stays synchronized with the selected site theme.

## Result

The Profile page now consistently follows the site's dark/light mode when navigating between pages.