### PR TITLE
WD; Add RTL support for Arabic locale in layout, header and footer

### DIFF
--- a/next_webapp/src/app/[locale]/layout.tsx
+++ b/next_webapp/src/app/[locale]/layout.tsx
@@ -14,7 +14,7 @@ export default async function LocaleLayout({
   const messages = await getMessages({ locale });
 
   return (
-    <html lang={locale} suppressHydrationWarning>
+    <html lang={locale} dir={locale === "ar" ? "rtl" : "ltr"} suppressHydrationWarning>
       <head>
         <script
           dangerouslySetInnerHTML={{

--- a/next_webapp/src/components/Footer.tsx
+++ b/next_webapp/src/components/Footer.tsx
@@ -244,7 +244,7 @@ const Footer = () => {
         .quick-link::after {
           content: '';
           position: absolute;
-          left: 0;
+          inset-inline-start: 0;
           bottom: -1px;
           width: 0;
           height: 1px;
@@ -256,6 +256,10 @@ const Footer = () => {
           color: #ffffff;
           transform: translateX(5px);
           text-shadow: 0 0 12px rgba(255,255,255,0.6);
+        }
+
+        [dir="rtl"] .quick-link:hover {
+          transform: translateX(-5px);
         }
 
         .quick-link:hover::after {
@@ -270,6 +274,11 @@ const Footer = () => {
 
         .quick-link:hover .arrow {
           opacity: 1;
+        }
+
+        [dir="rtl"] .quick-link .arrow {
+          display: inline-block;
+          transform: scaleX(-1);
         }
 
         .section-heading {
@@ -307,27 +316,27 @@ const Footer = () => {
             border-radius: 10px;
           }
           .footer-col-links.footer-tight-pad {
-            padding-left: 12px !important;
-            padding-right: 12px !important;
+            padding-inline-start: 12px !important;
+            padding-inline-end: 12px !important;
           }
           .footer-col-connect.footer-tight-pad {
-            padding-right: 12px !important;
+            padding-inline-end: 12px !important;
           }
         }
 
         /* Phone only: single column + centered; from md (tablet) up = same as desktop */
         @media (max-width: 767px) {
           .footer-col-links {
-            border-left: none !important;
-            border-right: none !important;
-            padding-left: 0 !important;
-            padding-right: 0 !important;
+            border-inline-start: none !important;
+            border-inline-end: none !important;
+            padding-inline-start: 0 !important;
+            padding-inline-end: 0 !important;
             align-items: center !important;
           }
 
           .footer-col-connect {
-            border-right: none !important;
-            padding-right: 0 !important;
+            border-inline-end: none !important;
+            padding-inline-end: 0 !important;
             align-items: center !important;
           }
 
@@ -449,7 +458,7 @@ const Footer = () => {
 									lineHeight: "1.7",
 									textShadow: "0 1px 4px rgba(0,0,0,0.25)",
 								}}
-								className="max-w-[220px] text-center text-[0.9rem] md:max-w-none md:text-left md:text-[0.85rem] lg:text-[0.9rem]"
+								className="max-w-[220px] text-center text-[0.9rem] md:max-w-none md:text-start md:text-[0.85rem] lg:text-[0.9rem]"
 							>
 								Exploring Melbourne&#39;s open data to build smarter
 								communities.
@@ -459,13 +468,13 @@ const Footer = () => {
 						<div
 							className="footer-col-links footer-tight-pad flex min-w-0 flex-col items-center gap-4 md:items-start"
 							style={{
-								borderLeft: "1px solid rgba(255,255,255,0.3)",
-								borderRight: "1px solid rgba(255,255,255,0.3)",
-								paddingLeft: "28px",
-								paddingRight: "28px",
+								borderInlineStart: "1px solid rgba(255,255,255,0.3)",
+								borderInlineEnd: "1px solid rgba(255,255,255,0.3)",
+								paddingInlineStart: "28px",
+								paddingInlineEnd: "28px",
 							}}
 						>
-							<p className="section-heading text-center md:text-left">
+							<p className="section-heading text-center md:text-start">
 								Quick Links
 							</p>
 							<div className="heading-bar" />
@@ -485,18 +494,18 @@ const Footer = () => {
 						<div
 							className="footer-col-connect footer-tight-pad flex min-w-0 flex-col items-center gap-4 md:items-start"
 							style={{
-								borderRight: "1px solid rgba(255,255,255,0.3)",
-								paddingRight: "28px",
+								borderInlineEnd: "1px solid rgba(255,255,255,0.3)",
+								paddingInlineEnd: "28px",
 							}}
 						>
-							<p className="section-heading text-center md:text-left">Connect</p>
+							<p className="section-heading text-center md:text-start">Connect</p>
 							<div className="heading-bar" />
 
 							<a
 								href="https://data.melbourne.vic.gov.au/pages/home/"
 								target="_blank"
 								rel="noopener noreferrer"
-								className="flex min-w-0 flex-wrap justify-center break-words text-center md:justify-start md:text-left md:text-[0.82rem] lg:text-[0.95rem]"
+								className="flex min-w-0 flex-wrap justify-center break-words text-center md:justify-start md:text-start md:text-[0.82rem] lg:text-[0.95rem]"
 								style={{
 									color: "rgba(255,255,255,0.92)",
 									textDecoration: "none",
@@ -523,7 +532,7 @@ const Footer = () => {
 
 							<div className="flex flex-col items-center md:items-start">
 								<p
-									className="text-center md:text-left"
+									className="text-center md:text-start"
 									style={{
 										fontSize: "0.78rem",
 										color: "rgba(255,255,255,0.85)",
@@ -562,7 +571,7 @@ const Footer = () => {
 						</div>
 
 						<div className="flex min-w-0 flex-col items-center gap-4 md:items-start">
-							<p className="section-heading text-center md:text-left">
+							<p className="section-heading text-center md:text-start">
 								Newsletter
 							</p>
 							<div className="heading-bar" />
@@ -573,7 +582,7 @@ const Footer = () => {
 									lineHeight: "1.7",
 									textShadow: "0 1px 4px rgba(0,0,0,0.25)",
 								}}
-								className="max-w-[220px] text-center text-[0.95rem] md:max-w-none md:w-full md:text-left md:text-[0.85rem] lg:text-[0.95rem]"
+								className="max-w-[220px] text-center text-[0.95rem] md:max-w-none md:w-full md:text-start md:text-[0.85rem] lg:text-[0.95rem]"
 							>
 								Get Melbourne open-data updates first.
 							</p>

--- a/next_webapp/src/components/Header.tsx
+++ b/next_webapp/src/components/Header.tsx
@@ -157,7 +157,7 @@ const Header = () => {
 
 	// Dropdown panel – solid card so text is always readable on any hero image
 	const dropdownPanel =
-		"absolute left-0 top-full mt-2 z-[100] w-52 overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900";
+		"absolute start-0 top-full mt-2 z-[100] w-52 overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900";
 
 	const dropdownItem = (active: boolean) =>
 		`flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-all duration-150 ${
@@ -252,7 +252,7 @@ const Header = () => {
 
 						{/* Desktop nav links */}
 						<nav
-							className="ml-8 hidden lg:flex lg:items-center gap-2"
+							className="ms-8 hidden lg:flex lg:items-center gap-2"
 							aria-label="Main navigation"
 						>
 							{visibleNavItems.map((item) =>
@@ -420,7 +420,7 @@ const Header = () => {
 										</button>
 
 										{openMobileDropdown === item.name && (
-											<div className="mt-1 ml-3 space-y-0.5 border-l-2 border-green-200 pl-3 dark:border-green-800/60">
+											<div className="mt-1 ms-3 space-y-0.5 border-s-2 border-green-200 ps-3 dark:border-green-800/60">
 												{item.items.map((sub) => (
 													<Link
 														key={sub.name}
@@ -457,12 +457,12 @@ const Header = () => {
 									/>
 								</button>
 								{isLangOpen && (
-									<div className="mt-1 ml-3 space-y-0.5 border-l-2 border-green-200 pl-3 dark:border-green-800/60">
+									<div className="mt-1 ms-3 space-y-0.5 border-s-2 border-green-200 ps-3 dark:border-green-800/60">
 										{languages.map((lang) => (
 											<button
 												key={lang.locale}
 												onClick={() => selectLanguage(lang.locale)}
-												className="block w-full text-left px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 text-gray-700 hover:text-green-700 hover:bg-green-50 dark:text-gray-200 dark:hover:text-green-300 dark:hover:bg-green-900/20"
+												className="block w-full text-start px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 text-gray-700 hover:text-green-700 hover:bg-green-50 dark:text-gray-200 dark:hover:text-green-300 dark:hover:bg-green-900/20"
 											>
 												{lang.name}
 											</button>
@@ -475,7 +475,7 @@ const Header = () => {
 								<button
 									type="button"
 									onClick={openLogoutConfirm}
-									className="block w-full text-left text-green-600 hover:text-green-900 dark:text-green-400 dark:hover:text-green-300 px-3 py-2 rounded-md text-base font-medium"
+									className="block w-full text-start text-green-600 hover:text-green-900 dark:text-green-400 dark:hover:text-green-300 px-3 py-2 rounded-md text-base font-medium"
 								>
 									{t("Log Out")}
 								</button>


### PR DESCRIPTION
## What this PR does
Adds right-to-left (RTL) language support for the Arabic locale.

## Changes
- **layout.tsx**: the `<html>` tag now sets `dir="rtl"` when the active locale
  is Arabic (`ar`), and `dir="ltr"` for all other languages.
- **Header.tsx**: replaced physical CSS classes (`ml-*`, `left-0`, `text-left`)
  with logical ones (`ms-*`, `start-0`, `text-start`) so the header mirrors
  automatically under RTL.
- **Footer.tsx**: same logical CSS refactor for the text alignment, and
  converted the inline-style borders/padding and the raw `<style>` block to
  logical CSS properties (`border-inline-*`, `padding-inline-*`,
  `inset-inline-start`). Also added RTL-specific rules so the quick-link hover
  nudge and arrow point the correct way in Arabic.

## Testing
- Visited `/ar` and confirmed `dir="rtl"` is applied and the header and footer
  mirror correctly (align right).
- Confirmed `/en` and other languages still display left-to-right and are
  unaffected.
- Checked dark mode and all 8 languages still work.
