### PR TITLE
WD: feat(a11y): add dialog semantics and label associations to shared com…

### DIFF
--- a/next_webapp/src/components/SearchFilter.tsx
+++ b/next_webapp/src/components/SearchFilter.tsx
@@ -110,8 +110,9 @@ export default function SearchFilter({ onFilterChange }: SearchFilterProps) {
 
             {/* Search Query */}
             <div className="mb-6">
-                <label className="block text-sm font-medium mb-2">Search Query</label>
+                <label htmlFor="search-query" className="block text-sm font-medium mb-2">Search Query</label>
                 <input
+                    id="search-query"
                     type="text"
                     value={draft.query}
                     onChange={(e) => setDraft(prev => ({ ...prev, query: e.target.value }))}
@@ -146,8 +147,9 @@ export default function SearchFilter({ onFilterChange }: SearchFilterProps) {
 
             {/* Sort Options */}
             <div className="mb-6">
-                <label className="block text-sm font-medium mb-2">Sort By</label>
+                <label htmlFor="sort-by" className="block text-sm font-medium mb-2">Sort By</label>
                 <select
+                    id="sort-by"
                     value={`${draft.sortBy}-${draft.sortOrder}`}
                     onChange={(e) => {
                         const [sortBy, sortOrder] = e.target.value.split('-');

--- a/next_webapp/src/components/admin/ConfirmModal.tsx
+++ b/next_webapp/src/components/admin/ConfirmModal.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef } from "react";
+
 type ConfirmModalProps = {
   open: boolean;
   title: string;
@@ -21,16 +23,80 @@ export default function ConfirmModal({
   onConfirm,
   onCancel,
 }: ConfirmModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedElement = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    previouslyFocusedElement.current = document.activeElement as HTMLElement | null;
+    cancelButtonRef.current?.focus();
+
+    const getFocusableElements = () => {
+      if (!modalRef.current) return [];
+      return Array.from(
+        modalRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter((el) => !el.hasAttribute("disabled"));
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+        return;
+      }
+
+      if (e.key === "Tab") {
+        const focusableElements = getFocusableElements();
+        if (focusableElements.length === 0) return;
+
+        const first = focusableElements[0];
+        const last = focusableElements[focusableElements.length - 1];
+        const isInsideModal = modalRef.current?.contains(document.activeElement);
+
+        if (e.shiftKey) {
+          if (!isInsideModal || document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (!isInsideModal || document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      previouslyFocusedElement.current?.focus();
+    };
+  }, [open, onCancel]);
+
   if (!open) return null;
 
   return (
     <div className="fixed inset-0 z-[999] flex items-center justify-center bg-black/40 px-4">
-      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
-        <h2 className="text-xl font-semibold text-[#1F8F50]">{title}</h2>
-        <p className="mt-3 text-sm text-gray-700">{message}</p>
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-modal-title"
+        aria-describedby="confirm-modal-message"
+        className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
+      >
+        <h2 id="confirm-modal-title" className="text-xl font-semibold text-[#1F8F50]">{title}</h2>
+        <p id="confirm-modal-message" className="mt-3 text-sm text-gray-700">{message}</p>
 
         <div className="mt-6 flex justify-end gap-3">
           <button
+            ref={cancelButtonRef}
             type="button"
             onClick={onCancel}
             className="rounded-xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"


### PR DESCRIPTION
Task 5: Accessibility fixes for ConfirmModal and SearchFilter (COMP-A11Y-015, 003, 004)

## What this does
Remediates the three highest-priority accessibility findings from the Sprint 1 audit.

**ConfirmModal (COMP-A11Y-015, Critical)**
- Added `role="dialog"`, `aria-modal`, `aria-labelledby`, `aria-describedby`
- Implemented a keyboard focus trap so focus stays inside the modal while open
- Escape now closes the modal and restores focus to the triggering button

**SearchFilter (COMP-A11Y-003, 004, High)**
- Linked the "Search Query" label/input via matching `htmlFor`/`id`
- Linked the "Sort By" label/select via matching `htmlFor`/`id`

## Notes
No visual changes — semantic and keyboard-behaviour only.

## Files changed
- `src/components/admin/ConfirmModal.tsx`
- `src/components/SearchFilter.tsx`