### PR TITLE
WD: feat: add back to homepage link in admin dropdown and admin portal to…

### DIFF
--- a/next_webapp/messages/ar.json
+++ b/next_webapp/messages/ar.json
@@ -20,6 +20,7 @@
     "Use Cases": "حالات الاستخدام",
     "Statistics": "الإحصائيات",
     "Upload": "تحميل",
+    "Admin Portal": "بوابة المشرف",
     "Log In": "تسجيل الدخول",
     "Log Out": "تسجيل الخروج",
     "logout_confirm_title": "تسجيل الخروج؟",

--- a/next_webapp/messages/cn.json
+++ b/next_webapp/messages/cn.json
@@ -20,6 +20,7 @@
     "Use Cases": "使用案例",
     "Statistics": "统计",
     "Upload": "上传",
+    "Admin Portal": "管理员门户",
     "Log In": "登录",
     "Log Out": "退出登录",
     "logout_confirm_title": "确认退出登录？",

--- a/next_webapp/messages/el.json
+++ b/next_webapp/messages/el.json
@@ -20,6 +20,7 @@
     "Use Cases": "Περιπτώσεις Χρήσης",
     "Statistics": "Στατιστικά",
     "Upload": "Ανέβασμα",
+    "Admin Portal": "Πύλη διαχειριστή",
     "Log In": "Σύνδεση",
     "Log Out": "Αποσύνδεση",
     "logout_confirm_title": "Αποσύνδεση;",

--- a/next_webapp/messages/en.json
+++ b/next_webapp/messages/en.json
@@ -20,6 +20,7 @@
     "Use Cases": "Use Cases",
     "Statistics": "Statistics",
     "Upload": "Upload",
+    "Admin Portal": "Admin Portal",
     "Log In": "Log In",
     "Log Out": "Log Out",
     "logout_confirm_title": "Sign out?",

--- a/next_webapp/messages/es.json
+++ b/next_webapp/messages/es.json
@@ -20,6 +20,7 @@
     "Use Cases": "Casos de Uso",
     "Statistics": "Estadísticas",
     "Upload": "Subir",
+    "Admin Portal": "Portal de administración",
     "Log In": "Iniciar Sesión",
     "Log Out": "Cerrar sesión",
     "logout_confirm_title": "¿Cerrar sesión?",

--- a/next_webapp/messages/hi.json
+++ b/next_webapp/messages/hi.json
@@ -20,6 +20,7 @@
     "Use Cases": "उपयोग के मामले",
     "Statistics": "आँकड़े",
     "Upload": "अपलोड",
+    "Admin Portal": "व्यवस्थापक पोर्टल",
     "Log In": "लॉग इन करें",
     "Log Out": "लॉग आउट",
     "logout_confirm_title": "लॉग आउट करें?",

--- a/next_webapp/messages/it.json
+++ b/next_webapp/messages/it.json
@@ -20,6 +20,7 @@
     "Use Cases": "Casi d'uso",
     "Statistics": "Statistiche",
     "Upload": "Carica",
+    "Admin Portal": "Portale di amministrazione",
     "Log In": "Accedi",
     "Log Out": "Esci",
     "logout_confirm_title": "Uscire?",

--- a/next_webapp/messages/vi.json
+++ b/next_webapp/messages/vi.json
@@ -20,6 +20,7 @@
     "Use Cases": "Trường hợp sử dụng",
     "Statistics": "Thống kê",
     "Upload": "Tải lên",
+    "Admin Portal": "Cổng quản trị",
     "Log In": "Đăng nhập",
     "Log Out": "Đăng xuất",
     "logout_confirm_title": "Đăng xuất?",

--- a/next_webapp/src/components/Header.tsx
+++ b/next_webapp/src/components/Header.tsx
@@ -23,7 +23,15 @@ const languages = [
 	{ name: "Vietnamese (Tiếng Việt)", locale: "vi" },
 ] as const;
 
-const navItems = [
+type NavItem =
+	| { type: "link"; name: string; link: string }
+	| {
+			type: "dropdown";
+			name: string;
+			items: readonly { name: string; link: string }[];
+	  };
+
+const navItems: readonly NavItem[] = [
 	{ type: "link", name: "Home", link: "/" },
 	{ type: "link", name: "About Us", link: "/about" },
 	{ type: "link", name: "Profile", link: "/profile" },
@@ -50,14 +58,17 @@ const Header = () => {
 	const [openMobileDropdown, setOpenMobileDropdown] = useState<string | null>(null);
 	const [isLangOpen, setIsLangOpen] = useState(false);
 	const [isLoggedIn, setIsLoggedIn] = useState(false);
+	const [isAdmin, setIsAdmin] = useState(false);
 	const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
 	const { theme, toggleTheme } = useTheme();
 	const exploreRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		const token = localStorage.getItem("token");
+		const userStr = localStorage.getItem("user");
 		if (!token) {
 			setIsLoggedIn(false);
+			setIsAdmin(false);
 			return;
 		}
 		try {
@@ -72,14 +83,24 @@ const Header = () => {
 				localStorage.removeItem("user");
 				localStorage.removeItem("userId");
 				setIsLoggedIn(false);
+				setIsAdmin(false);
 			} else {
 				setIsLoggedIn(true);
+				if (userStr) {
+					try {
+						const userData = JSON.parse(userStr);
+						setIsAdmin(userData.roleId === 1);
+					} catch {
+						setIsAdmin(false);
+					}
+				}
 			}
 		} catch {
 			localStorage.removeItem("token");
 			localStorage.removeItem("user");
 			localStorage.removeItem("userId");
 			setIsLoggedIn(false);
+			setIsAdmin(false);
 		}
 	}, []);
 
@@ -108,6 +129,7 @@ const Header = () => {
 		localStorage.removeItem("user");
 		localStorage.removeItem("userId");
 		setIsLoggedIn(false);
+		setIsAdmin(false);
 		setShowLogoutConfirm(false);
 		i18nRouter.push("/");
 	};
@@ -165,9 +187,12 @@ const Header = () => {
 				? "bg-gradient-to-r from-green-500 to-emerald-600 text-white"
 				: "text-gray-700 hover:bg-green-50 hover:text-green-700 dark:text-gray-200 dark:hover:bg-green-900/25 dark:hover:text-green-300"
 		}`;
-		const visibleNavItems = navItems.filter(
-	(item) => item.name !== "Profile" || isLoggedIn
-);
+	const visibleNavItems: NavItem[] = [
+		...navItems.filter((item) => item.name !== "Profile" || isLoggedIn),
+		...(isAdmin
+			? [{ type: "link" as const, name: "Admin Portal", link: "/admin/dashboard" }]
+			: []),
+	];
 
 	return (
 		<>

--- a/next_webapp/src/components/admin/AdminHeader.tsx
+++ b/next_webapp/src/components/admin/AdminHeader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bell, Search, UserCircle2, Settings, LogOut } from "lucide-react";
+import { Bell, Search, UserCircle2, Settings, LogOut, Home } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -40,14 +40,16 @@ export default function AdminHeader() {
   return (
     <header className="flex h-[72px] w-full items-center justify-between border-b border-[#D9D9D9] bg-[#F1EFEF] px-3 sm:px-4 md:px-6">
       <div className="flex shrink-0 items-center">
-        <Image
-          src="/img/new-logo-green.png"
-          alt="Chameleon Logo"
-          width={60}
-          height={24}
-          className="object-contain sm:w-[72px] md:w-[90px]"
-          priority
-        />
+        <Link href={`/${locale}`} aria-label="Go to Homepage">
+          <Image
+            src="/img/new-logo-green.png"
+            alt="Chameleon Logo"
+            width={60}
+            height={24}
+            className="cursor-pointer object-contain transition-transform duration-200 hover:scale-105 sm:w-[72px] md:w-[90px]"
+            priority
+          />
+        </Link>
       </div>
 
       <div className="mx-2 flex w-full min-w-0 max-w-[160px] items-center rounded-lg border border-[#D9D9D9] bg-white px-3 py-2 sm:mx-4 sm:max-w-[260px] md:max-w-[420px]">
@@ -77,7 +79,16 @@ export default function AdminHeader() {
           </button>
 
           {profileOpen && (
-            <div className="absolute right-0 top-10 z-50 w-44 rounded-xl border border-[#E5E7EB] bg-white p-2 shadow-lg">
+            <div className="absolute right-0 top-10 z-50 w-48 space-y-1 rounded-xl border border-[#E5E7EB] bg-white p-2 shadow-lg">
+              <Link
+                href={`/${locale}`}
+                onClick={() => setProfileOpen(false)}
+                className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-[#1A1A1A] transition hover:bg-[#F3F4F6]"
+              >
+                <Home size={16} />
+                Back to Homepage
+              </Link>
+
               <Link
                 href={`/${locale}/admin/settings`}
                 onClick={() => setProfileOpen(false)}
@@ -87,14 +98,14 @@ export default function AdminHeader() {
                 Settings
               </Link>
 
-            <button
-              type="button"
-              onClick={handleLogout}
-              className="flex h-10 w-full min-w-[96px] items-center justify-center gap-2 rounded-lg border border-green-600 bg-white px-4 text-sm font-medium text-green-600 transition-all duration-200 transform hover:scale-105 hover:bg-green-50 hover:text-green-700 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
-            >
-              <LogOut size={16} />
-            Logout
-            </button>
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="flex h-10 w-full min-w-[96px] items-center justify-center gap-2 rounded-lg border border-green-600 bg-white px-4 text-sm font-medium text-green-600 transition-all duration-200 transform hover:scale-105 hover:bg-green-50 hover:text-green-700 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+              >
+                <LogOut size={16} />
+                Logout
+              </button>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
Improves the navigation experience for admin users by allowing them to seamlessly toggle between the Admin Portal and the main application homepage without having to log out or manually change the URL.

## Changes Made
- **Admin Portal Header (`AdminHeader.tsx`)**:
  - Added a **"Back to Homepage"** link with a `Home` icon to the profile dropdown menu.
  - Styled the new menu item to match existing "Settings" and "Logout" dropdown items.
  - Made the Chameleon logo in the admin header clickable to navigate to the homepage.
- **Main Website Navigation (`Header.tsx`)**:
  - Added automatic admin detection (`roleId === 1`).
  - Added an **"Admin Portal"** navigation link to desktop and mobile menus when an admin user is logged in, linking directly to `/admin/dashboard`.
- **Localization (`messages/*.json`)**:
  - Added `"Admin Portal"` translation key to all supported locale dictionaries (`en`, `es`, `cn`, `ar`, `el`, `hi`, `it`, `vi`).

## Acceptance Criteria Checklist
- [x] Add a "Back to Homepage" button/link to the user profile dropdown menu.
- [x] When clicked, the user is redirected to the main application homepage.
- [x] Ensure the new menu item matches the existing styling of "Settings" and "Logout".
- [x] Feature an "Admin Portal" link on the homepage dropdown/navigation when logged in as an admin.

## How to Test
1. Log in with an admin account (`roleId: 1`) and go to `/admin/dashboard`.
2. Click the profile icon in the top right and verify the **"Back to Homepage"** option is visible and styled properly.
3. Click **"Back to Homepage"** and confirm you are redirected to `/`.
4. On the main website header, verify that the **"Admin Portal"** link appears and successfully navigates back to `/admin/dashboard`.

<img width="725" height="302" alt="{AE203F4D-2270-4C92-A6D3-CEAC606A8FC9}" src="https://github.com/user-attachments/assets/7f21e86a-815c-4834-8c6e-35cfee1c5af4" />

<img width="712" height="258" alt="{727953AA-60B6-4157-B72C-8084F4BE6027}" src="https://github.com/user-attachments/assets/ace56877-d46f-4434-8b2a-6b019e2bbeff" />

