### PR TITLE
WD: global API error handling with apiFetch, toast notifications and ErrorBoundary

### DIFF
--- a/next_webapp/package-lock.json
+++ b/next_webapp/package-lock.json
@@ -37,6 +37,7 @@
         "react-tag-input-component": "^2.0.2",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
+        "sonner": "^2.0.8",
         "winston": "^3.19.0"
       },
       "devDependencies": {
@@ -20767,6 +20768,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.8.tgz",
+      "integrity": "sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/source-map-js": {

--- a/next_webapp/package.json
+++ b/next_webapp/package.json
@@ -39,6 +39,7 @@
     "react-tag-input-component": "^2.0.2",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
+    "sonner": "^2.0.8",
     "winston": "^3.19.0"
   },
   "devDependencies": {

--- a/next_webapp/src/app/[locale]/admin/activity-history/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/activity-history/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { ArrowUpDown } from "lucide-react";
 import Pagination from "@/components/Pagination";
+import { apiFetch } from "@/lib/apiFetch";
 
 interface ActivityEntry {
   id: number;
@@ -60,9 +61,10 @@ export default function ActivityHistoryPage() {
       });
       if (searchTerm) params.set("search", searchTerm);
 
-      const res = await fetch(`/api/admin/activity-history?${params}`, { headers: authHeaders() });
-      const json = await res.json();
-      if (!json.success) throw new Error(json.message || "Failed to fetch activity");
+      const json = await apiFetch<{ success: boolean; data: ActivityEntry[]; pagination: { total: number; totalPages: number } }>(
+        `/api/admin/activity-history?${params}`,
+        { headers: authHeaders(), silent: true }
+      );
       setEntries(json.data || []);
       setTotal(json.pagination.total);
       setTotalPages(json.pagination.totalPages);

--- a/next_webapp/src/app/[locale]/admin/blogs/add/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/blogs/add/page.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
 import BlogForm from "../components/BlogsForm";
 import AdminToast from "@/components/admin/AdminToast";
+import { apiFetch, ApiError } from "@/lib/apiFetch";
 export default function AddBlog() {
   const router = useRouter();
   const { locale } = useParams<{ locale: string }>();
@@ -30,7 +31,7 @@ export default function AddBlog() {
         formData.append("cover_img", data.coverImage);
       }
 
-      const res = await fetch("/api/blogs", {
+      await apiFetch("/api/blogs", {
         method: "POST",
         headers: {
           "x-user-id": String(userId),
@@ -39,17 +40,8 @@ export default function AddBlog() {
           ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         body: formData,
+        silent: true,
       });
-
-      const json = await res.json();
-
-      if (!res.ok || !json.success) {
-        const msg = json.errors
-          ? Object.values(json.errors).join(", ")
-          : json.message || "Failed to create blog";
-        setError(msg);
-        return;
-      }
 
       setToast({
         message: "Blog added successfully.",
@@ -61,7 +53,13 @@ export default function AddBlog() {
       }, 1000);
     } catch (e) {
       console.error(e);
-      setError("Something went wrong. Please try again.");
+      const body = e instanceof ApiError ? (e.body as any) : null;
+      const msg = body?.errors
+        ? Object.values(body.errors).join(", ")
+        : e instanceof Error
+          ? e.message
+          : "Something went wrong. Please try again.";
+      setError(msg);
     } finally {
       setSubmitting(false);
     }

--- a/next_webapp/src/app/[locale]/admin/blogs/edit/[id]/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/blogs/edit/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import BlogForm from "../../components/BlogsForm";
+import { apiFetch, ApiError } from "@/lib/apiFetch";
 
 function authHeaders(user: any) {
   const userId = user.userId ?? user.id ?? "";
@@ -29,13 +30,7 @@ export default function EditBlogPage() {
     const fetchBlog = async () => {
       try {
         const user = JSON.parse(localStorage.getItem("user") || "{}");
-        const res = await fetch(`/api/blogs/${id}`, { headers: authHeaders(user) });
-        const json = await res.json();
-
-        if (!res.ok || !json.success) {
-          setLoadError(json.message || "Failed to load blog");
-          return;
-        }
+        const json = await apiFetch<any>(`/api/blogs/${id}`, { headers: authHeaders(user), silent: true });
 
         const b = json.data;
         setInitialData({
@@ -47,7 +42,7 @@ export default function EditBlogPage() {
         });
       } catch (e) {
         console.error(e);
-        setLoadError("Failed to load blog");
+        setLoadError(e instanceof Error ? e.message : "Failed to load blog");
       }
     };
 
@@ -70,26 +65,23 @@ export default function EditBlogPage() {
         formData.append("cover_img", data.coverImage);
       }
 
-      const res = await fetch(`/api/blogs/${id}`, {
+      await apiFetch(`/api/blogs/${id}`, {
         method: "PUT",
         headers: authHeaders(user),
         body: formData,
+        silent: true,
       });
-
-      const json = await res.json();
-
-      if (!res.ok || !json.success) {
-        const msg = json.errors
-          ? Object.values(json.errors).join(", ")
-          : json.message || "Failed to update blog";
-        setSubmitError(msg);
-        return;
-      }
 
       router.push(`/${locale}/admin/blogs`);
     } catch (e) {
       console.error(e);
-      setSubmitError("Something went wrong. Please try again.");
+      const body = e instanceof ApiError ? (e.body as any) : null;
+      const msg = body?.errors
+        ? Object.values(body.errors).join(", ")
+        : e instanceof Error
+          ? e.message
+          : "Something went wrong. Please try again.";
+      setSubmitError(msg);
     } finally {
       setSubmitting(false);
     }

--- a/next_webapp/src/app/[locale]/admin/blogs/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/blogs/page.tsx
@@ -7,6 +7,7 @@ import BlogTable from "./components/BlogsTable";
 import ConfirmModal from "@/components/admin/ConfirmModal";
 import AdminToast from "@/components/admin/AdminToast";
 import Pagination from "@/components/Pagination";
+import { apiFetch } from "@/lib/apiFetch";
 
 function authHeaders() {
   const user = JSON.parse(localStorage.getItem("user") || "{}");
@@ -46,15 +47,12 @@ export default function BlogsPage({ params }: { params: Promise<{ locale: string
       if (searchTerm) { params.set("search", searchTerm); params.set("search_by", "all"); }
       if (dateFilter) { params.set("date_from", dateFilter); params.set("date_to", dateFilter); }
 
-      const res = await fetch(`/api/blogs?${params}`, { headers: authHeaders() });
-      const json = await res.json();
-      if (json.success) {
-        setBlogs(json.data ?? []);
-        setTotal(json.pagination?.total ?? 0);
-        setTotalPages(json.pagination?.totalPages ?? 1);
-      }
+      const json = await apiFetch<any>(`/api/blogs?${params}`, { headers: authHeaders() });
+      setBlogs(json.data ?? []);
+      setTotal(json.pagination?.total ?? 0);
+      setTotalPages(json.pagination?.totalPages ?? 1);
     } catch (e) {
-      console.error(e);
+      console.error(e); // apiFetch already showed a toast; this was previously a fully silent failure
     } finally {
       setLoading(false);
     }
@@ -82,26 +80,18 @@ export default function BlogsPage({ params }: { params: Promise<{ locale: string
     if (!deleteTarget) return;
   
     try {
-      const res = await fetch(`/api/blogs/${deleteTarget.id}`, {
+      await apiFetch(`/api/blogs/${deleteTarget.id}`, {
         method: "DELETE",
         headers: authHeaders(),
+        silent: true,
       });
-  
-      const json = await res.json();
-  
-      if (json.success) {
-        setToast({ message: "Blog deleted successfully.", type: "success" });
-        setDeleteTarget(null);
-        fetchBlogs(search, selectedDate, page);
-      } else {
-        setToast({
-          message: json.message || "Failed to delete blog.",
-          type: "error",
-        });
-      }
+
+      setToast({ message: "Blog deleted successfully.", type: "success" });
+      setDeleteTarget(null);
+      fetchBlogs(search, selectedDate, page);
     } catch (e) {
       console.error(e);
-      setToast({ message: "Failed to delete blog.", type: "error" });
+      setToast({ message: e instanceof Error ? e.message : "Failed to delete blog.", type: "error" });
     }
   };
 

--- a/next_webapp/src/app/[locale]/admin/categories/add/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/categories/add/page.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { FolderPlus, ImagePlus, Save } from "lucide-react";
 import AdminToast from "@/components/admin/AdminToast";
+import { apiFetch } from "@/lib/apiFetch";
 function getAuthHeaders() {
   const user = JSON.parse(localStorage.getItem("user") || "{}");
   const userId = user.userId ?? user.id ?? localStorage.getItem("userId") ?? "";
@@ -53,23 +54,23 @@ export default function AddCategoryPage() {
         formData.append("file", imageFile);
         formData.append("folder", "categories");
 
-        const uploadRes = await fetch("/api/upload", {
-          method: "POST",
-          headers: authHeaders,
-          body: formData,
-        });
-        const uploadJson = await uploadRes.json();
-
-        if (!uploadJson.success) {
-          setError("Image upload failed: " + (uploadJson.message || "Unknown error"));
+        try {
+          const uploadJson = await apiFetch<{ success: boolean; url?: string }>("/api/upload", {
+            method: "POST",
+            headers: authHeaders,
+            body: formData,
+            silent: true,
+          });
+          coverImgUrl = uploadJson.url ?? null;
+        } catch (e) {
+          setError("Image upload failed: " + (e instanceof Error ? e.message : "Unknown error"));
           setLoading(false);
           return;
         }
-        coverImgUrl = uploadJson.url;
       }
 
       // 2. Create the category
-      const res = await fetch("/api/categories", {
+      await apiFetch("/api/categories", {
         method: "POST",
         headers: { "Content-Type": "application/json", ...authHeaders },
         body: JSON.stringify({
@@ -77,23 +78,18 @@ export default function AddCategoryPage() {
           description,
           cover_img: coverImgUrl,
         }),
+        silent: true,
       });
-      const json = await res.json();
-
-      if (!json.success) {
-        setError(json.message || "Failed to create category.");
-        setLoading(false);
-        return;
-      }
 
       setToast({ message: "Category added successfully.", type: "success" });
 
 setTimeout(() => {
   router.push(`/${locale}/admin/categories`);
 }, 1000);
-    } catch {
-      setError("Failed to create category.");
-      setToast({ message: "Failed to add category.", type: "error" });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Failed to create category.";
+      setError(message);
+      setToast({ message, type: "error" });
       setLoading(false);
     }
   }

--- a/next_webapp/src/app/[locale]/admin/categories/edit/[id]/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/categories/edit/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { FolderOpen, ImagePlus, Save } from "lucide-react";
+import { apiFetch } from "@/lib/apiFetch";
 
 function getAuthHeaders() {
   const user = JSON.parse(localStorage.getItem("user") || "{}");
@@ -39,20 +40,16 @@ export default function EditCategoryPage() {
       setFetchLoading(true);
       setFetchError("");
       try {
-        const res = await fetch(`/api/categories/${id}`, {
+        const json = await apiFetch<any>(`/api/categories/${id}`, {
           headers: getAuthHeaders(),
+          silent: true,
         });
-        const json = await res.json();
-        if (!json.success) {
-          setFetchError(json.message || "Category not found.");
-          return;
-        }
         setCategoryName(json.data.category_name || "");
         setDescription(json.data.description || "");
         setExistingImgUrl(json.data.cover_img || null);
         setImagePreview(json.data.cover_img || null);
-      } catch {
-        setFetchError("Failed to load category.");
+      } catch (e) {
+        setFetchError(e instanceof Error ? e.message : "Failed to load category.");
       } finally {
         setFetchLoading(false);
       }
@@ -83,22 +80,22 @@ export default function EditCategoryPage() {
         formData.append("file", imageFile);
         formData.append("folder", "categories");
 
-        const uploadRes = await fetch("/api/upload", {
-          method: "POST",
-          headers: authHeaders,
-          body: formData,
-        });
-        const uploadJson = await uploadRes.json();
-
-        if (!uploadJson.success) {
-          setSaveError("Image upload failed: " + (uploadJson.message || "Unknown error"));
+        try {
+          const uploadJson = await apiFetch<{ success: boolean; url?: string }>("/api/upload", {
+            method: "POST",
+            headers: authHeaders,
+            body: formData,
+            silent: true,
+          });
+          coverImgUrl = uploadJson.url ?? null;
+        } catch (e) {
+          setSaveError("Image upload failed: " + (e instanceof Error ? e.message : "Unknown error"));
           setSaving(false);
           return;
         }
-        coverImgUrl = uploadJson.url;
       }
 
-      const res = await fetch(`/api/categories/${id}`, {
+      await apiFetch(`/api/categories/${id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json", ...authHeaders },
         body: JSON.stringify({
@@ -106,18 +103,12 @@ export default function EditCategoryPage() {
           description,
           cover_img: coverImgUrl,
         }),
+        silent: true,
       });
-      const json = await res.json();
-
-      if (!json.success) {
-        setSaveError(json.message || "Failed to update category.");
-        setSaving(false);
-        return;
-      }
 
       router.push(`/${locale}/admin/categories`);
-    } catch {
-      setSaveError("Failed to update category.");
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Failed to update category.");
       setSaving(false);
     }
   }

--- a/next_webapp/src/app/[locale]/admin/categories/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/categories/page.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { Plus, Pencil, Trash2 } from "lucide-react";
 import Pagination from "@/components/Pagination";
+import { apiFetch, ApiError } from "@/lib/apiFetch";
 
 function getAuthHeaders(): HeadersInit {
   const user = JSON.parse(localStorage.getItem("user") || "{}");
@@ -49,24 +50,20 @@ export default function CategoriesPage() {
         page: String(currentPage),
         pageSize: String(PAGE_SIZE),
       });
-      const res = await fetch(`/api/categories?${params}`, {
+      const json = await apiFetch<any>(`/api/categories?${params}`, {
         headers: getAuthHeaders(),
+        silent: true,
       });
-      const json = await res.json();
-      if (res.status === 401) {
+      setCategories(json.data || []);
+      setTotalPages(json.pagination?.totalPages ?? 1);
+      setTotal(json.pagination?.total ?? 0);
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 401) {
         localStorage.removeItem("user");
         router.replace(`/${locale}/login`);
         return;
       }
-      if (json.success) {
-        setCategories(json.data || []);
-        setTotalPages(json.pagination?.totalPages ?? 1);
-        setTotal(json.pagination?.total ?? 0);
-      } else {
-        setError(json.message || "Failed to load categories.");
-      }
-    } catch {
-      setError("Failed to load categories.");
+      setError(e instanceof Error ? e.message : "Failed to load categories.");
     } finally {
       setLoading(false);
     }
@@ -80,36 +77,27 @@ export default function CategoriesPage() {
     if (!deleteTarget) return;
   
     try {
-      const res = await fetch(`/api/categories/${deleteTarget.id}`, {
+      await apiFetch(`/api/categories/${deleteTarget.id}`, {
         method: "DELETE",
         headers: getAuthHeaders(),
+        silent: true,
       });
-  
-      const json = await res.json();
-  
-      if (!json.success) {
-        setToast({
-          message: json.message || "Failed to delete category.",
-          type: "error",
-        });
-        return;
-      }
-  
+
       setToast({
         message: "Category deleted successfully.",
         type: "success",
       });
-  
+
       setDeleteTarget(null);
-  
+
       if (categories.length === 1 && page > 1) {
         setPage((p) => p - 1);
       } else {
         fetchCategories(page);
       }
-    } catch {
+    } catch (e) {
       setToast({
-        message: "Failed to delete category.",
+        message: e instanceof Error ? e.message : "Failed to delete category.",
         type: "error",
       });
     }

--- a/next_webapp/src/app/[locale]/admin/contributors/add/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/contributors/add/page.tsx
@@ -6,6 +6,7 @@ import ContributorForm, {
   ContributorFormData,
 } from "../components/ContributorForm";
 import AdminToast from "@/components/admin/AdminToast";
+import { apiFetch, ApiError } from "@/lib/apiFetch";
 
 export default function AddContributorPage() {
   const router = useRouter();
@@ -52,7 +53,7 @@ export default function AddContributorPage() {
         is_active: data.isActive,
       };
 
-      const response = await fetch("/api/contributors", {
+      await apiFetch("/api/contributors", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -67,20 +68,8 @@ export default function AddContributorPage() {
             : {}),
         },
         body: JSON.stringify(payload),
+        silent: true,
       });
-
-      const json = await response.json();
-
-      console.log("API Response:", { status: response.ok, success: json.success, data: json });
-
-      if (!response.ok || !json.success) {
-        const message = json.errors
-          ? Object.values(json.errors).flat().join(", ")
-          : json.message || "Failed to add contributor";
-
-        setError(message);
-        return;
-      }
 
       setToast({
         message: "Contributor added successfully.",
@@ -93,9 +82,14 @@ export default function AddContributorPage() {
     } catch (error) {
       console.error(error);
 
-      setError(
-        "Something went wrong. Please try again.",
-      );
+      const body = error instanceof ApiError ? (error.body as any) : null;
+      const message = body?.errors
+        ? Object.values(body.errors).flat().join(", ")
+        : error instanceof Error
+          ? error.message
+          : "Something went wrong. Please try again.";
+
+      setError(message);
     } finally {
       setSubmitting(false);
     }

--- a/next_webapp/src/app/[locale]/admin/contributors/edit/[id]/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/contributors/edit/[id]/page.tsx
@@ -6,6 +6,7 @@ import ContributorForm, {
   ContributorFormData,
 } from "../../components/ContributorForm";
 import AdminToast from "@/components/admin/AdminToast";
+import { apiFetch, ApiError } from "@/lib/apiFetch";
 
 type ApiContributor = {
   id: number | string;
@@ -70,21 +71,14 @@ export default function EditContributorPage() {
       setError("");
 
       try {
-        const response = await fetch(
+        const json = await apiFetch<any>(
           `/api/contributors/${id}`,
           {
             headers: getAuthHeaders(),
             cache: "no-store",
+            silent: true,
           },
         );
-
-        const json = await response.json();
-
-        if (!response.ok || !json.success) {
-          throw new Error(
-            json.message || "Contributor not found",
-          );
-        }
 
         const contributor: ApiContributor =
           json.data ?? json.contributor;
@@ -154,7 +148,7 @@ export default function EditContributorPage() {
         is_active: data.isActive,
       };
 
-      const response = await fetch(
+      await apiFetch(
         `/api/contributors/${id}`,
         {
           method: "PUT",
@@ -163,20 +157,9 @@ export default function EditContributorPage() {
             ...getAuthHeaders(),
           },
           body: JSON.stringify(payload),
+          silent: true,
         },
       );
-
-      const json = await response.json();
-
-      if (!response.ok || !json.success) {
-        const message = json.errors
-          ? Object.values(json.errors).flat().join(", ")
-          : json.message ||
-          "Failed to update contributor";
-
-        setError(message);
-        return;
-      }
 
       setToast({
         message: "Contributor updated successfully.",
@@ -189,9 +172,14 @@ export default function EditContributorPage() {
     } catch (error) {
       console.error(error);
 
-      setError(
-        "Something went wrong. Please try again.",
-      );
+      const body = error instanceof ApiError ? (error.body as any) : null;
+      const message = body?.errors
+        ? Object.values(body.errors).flat().join(", ")
+        : error instanceof Error
+          ? error.message
+          : "Something went wrong. Please try again.";
+
+      setError(message);
     } finally {
       setSubmitting(false);
     }

--- a/next_webapp/src/app/[locale]/admin/contributors/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/contributors/page.tsx
@@ -17,6 +17,7 @@ import {
   useState,
 } from "react";
 import AdminToast from "@/components/admin/AdminToast";
+import { apiFetch } from "@/lib/apiFetch";
 
 type CustomSelectOption = {
   value: string;
@@ -244,18 +245,11 @@ export default function ContributorsPage() {
     setLoading(true);
 
     try {
-      const response = await fetch("/api/contributors", {
+      const json = await apiFetch<any>("/api/contributors", {
         headers: getAuthHeaders(),
         cache: "no-store",
+        silent: true,
       });
-
-      const json = await response.json();
-
-      if (!response.ok || !json.success) {
-        throw new Error(
-          json.message || "Failed to load contributors",
-        );
-      }
 
       const contributorData =
         json.data ?? json.contributors ?? [];
@@ -269,7 +263,7 @@ export default function ContributorsPage() {
       console.error(error);
 
       setToast({
-        message: "Failed to load contributors.",
+        message: error instanceof Error ? error.message : "Failed to load contributors.",
         type: "error",
       });
     } finally {
@@ -371,21 +365,14 @@ export default function ContributorsPage() {
     setDeletingId(contributor.id);
 
     try {
-      const response = await fetch(
+      await apiFetch(
         `/api/contributors/${contributor.id}`,
         {
           method: "DELETE",
           headers: getAuthHeaders(),
+          silent: true,
         },
       );
-
-      const json = await response.json();
-
-      if (!response.ok || !json.success) {
-        throw new Error(
-          json.message || "Failed to delete contributor",
-        );
-      }
 
       setContributors((previous) =>
         previous.filter(

--- a/next_webapp/src/app/[locale]/admin/dashboard/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { LayoutGrid, Folder, BookOpen, Images } from "lucide-react";
 import AdminStatCard from "@/components/admin/AdminStatsCard";
 import AdminRecentActivity from "@/components/admin/AdminRecentActivity";
 import { storage } from "@/utils/storage";
+import { apiFetch } from "@/lib/apiFetch";
 
 function getAuthHeaders(): HeadersInit {
   let user: Record<string, any> = {};
@@ -35,17 +36,12 @@ export default function DashboardPage() {
     async function fetchStats() {
       try {
         const headers = getAuthHeaders();
-        const [totalRes, categoryRes, blogsRes, galleryRes] = await Promise.all([
-          fetch("/api/statistics/total-count"),
-          fetch("/api/statistics/by-category"),
-          fetch("/api/blogs?page=1&pageSize=1", { headers }),
-          fetch("/api/gallery?page=1&pageSize=1", { headers }),
+        const [totalData, categoryData, blogsData, galleryData] = await Promise.all([
+          apiFetch<any>("/api/statistics/total-count"),
+          apiFetch<any>("/api/statistics/by-category"),
+          apiFetch<any>("/api/blogs?page=1&pageSize=1", { headers }),
+          apiFetch<any>("/api/gallery?page=1&pageSize=1", { headers }),
         ]);
-
-        const totalData = await totalRes.json();
-        const categoryData = await categoryRes.json();
-        const blogsData = await blogsRes.json();
-        const galleryData = await galleryRes.json();
 
         if (totalData.success) {
           setTotalUseCases(String(totalData.total));
@@ -63,7 +59,7 @@ export default function DashboardPage() {
           setTotalGallery(String(galleryData.pagination?.total ?? 0));
         }
       } catch {
-        // Keep "—" on error
+        // Keep "—" on error; apiFetch already showed a toast
       } finally {
         setLoading(false);
       }

--- a/next_webapp/src/app/[locale]/admin/gallery/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/gallery/page.tsx
@@ -5,6 +5,7 @@ import { Plus, X, Upload, Search, Pencil } from "lucide-react";
 import AdminToast from "@/components/admin/AdminToast";
 import ConfirmModal from "@/components/admin/ConfirmModal";
 import { storage } from "@/utils/storage";
+import { apiFetch, ApiError } from "@/lib/apiFetch";
 
 type GalleryImage = {
   id: number;
@@ -73,17 +74,15 @@ export default function GalleryPage({ params }: { params: Promise<{ locale: stri
       });
       if (searchTerm) qs.set("search", searchTerm);
 
-      const res = await fetch(`/api/gallery?${qs}`, { headers: authHeaders() });
-      const json = await res.json();
-      if (json.success) {
-        setImages(json.data ?? []);
-        setTotal(json.pagination?.total ?? 0);
-        setTotalPages(json.pagination?.totalPages ?? 1);
-      } else {
-        setToast({ message: json.message || "Failed to fetch gallery.", type: "error" });
-      }
-    } catch {
-      setToast({ message: "Failed to fetch gallery.", type: "error" });
+      const json = await apiFetch<{ success: boolean; data: GalleryImage[]; pagination?: { total: number; totalPages: number } }>(
+        `/api/gallery?${qs}`,
+        { headers: authHeaders(), silent: true }
+      );
+      setImages(json.data ?? []);
+      setTotal(json.pagination?.total ?? 0);
+      setTotalPages(json.pagination?.totalPages ?? 1);
+    } catch (e) {
+      setToast({ message: e instanceof Error ? e.message : "Failed to fetch gallery.", type: "error" });
     } finally {
       setLoading(false);
     }
@@ -118,25 +117,21 @@ export default function GalleryPage({ params }: { params: Promise<{ locale: stri
       formData.append("title", uploadTitle.trim());
       formData.append("image", uploadFile);
 
-      const res = await fetch("/api/gallery", {
+      await apiFetch("/api/gallery", {
         method: "POST",
         headers: authHeaders(),
         body: formData,
+        silent: true,
       });
-      const json = await res.json();
 
-      if (json.success) {
-        setToast({ message: "Gallery photo uploaded successfully.", type: "success" });
-        closeUpload();
-        fetchImages(search, 1);
-        setPage(1);
-      } else {
-        const errMsg =
-          json.errors?.title || json.errors?.image || json.message || "Upload failed.";
-        setToast({ message: errMsg, type: "error" });
-      }
-    } catch {
-      setToast({ message: "Upload failed.", type: "error" });
+      setToast({ message: "Gallery photo uploaded successfully.", type: "success" });
+      closeUpload();
+      fetchImages(search, 1);
+      setPage(1);
+    } catch (e) {
+      const body = e instanceof ApiError ? (e.body as any) : null;
+      const errMsg = body?.errors?.title || body?.errors?.image || (e instanceof Error ? e.message : "Upload failed.");
+      setToast({ message: errMsg, type: "error" });
     } finally {
       setUploading(false);
     }
@@ -178,24 +173,20 @@ export default function GalleryPage({ params }: { params: Promise<{ locale: stri
       formData.append("title", editTitle.trim() || editTarget.title);
       if (editFile) formData.append("image", editFile);
 
-      const res = await fetch(`/api/gallery/${editTarget.id}`, {
+      await apiFetch(`/api/gallery/${editTarget.id}`, {
         method: "PUT",
         headers: authHeaders(),
         body: formData,
+        silent: true,
       });
-      const json = await res.json();
 
-      if (json.success) {
-        setToast({ message: "Gallery photo updated successfully.", type: "success" });
-        closeEdit();
-        fetchImages(search, page);
-      } else {
-        const errMsg =
-          json.errors?.title || json.errors?.image || json.message || "Update failed.";
-        setToast({ message: errMsg, type: "error" });
-      }
-    } catch {
-      setToast({ message: "Update failed.", type: "error" });
+      setToast({ message: "Gallery photo updated successfully.", type: "success" });
+      closeEdit();
+      fetchImages(search, page);
+    } catch (e) {
+      const body = e instanceof ApiError ? (e.body as any) : null;
+      const errMsg = body?.errors?.title || body?.errors?.image || (e instanceof Error ? e.message : "Update failed.");
+      setToast({ message: errMsg, type: "error" });
     } finally {
       setSaving(false);
     }
@@ -212,25 +203,20 @@ export default function GalleryPage({ params }: { params: Promise<{ locale: stri
   const confirmDelete = async () => {
     if (!deleteTarget) return;
     try {
-      const res = await fetch(`/api/gallery/${deleteTarget.id}`, {
+      await apiFetch(`/api/gallery/${deleteTarget.id}`, {
         method: "DELETE",
         headers: authHeaders(),
+        silent: true,
       });
-      const json = await res.json();
 
-      if (json.success) {
-        setToast({ message: "Gallery photo deleted successfully.", type: "success" });
-        setDeleteTarget(null);
-        setSelectedImage(null);
-        const newPage = images.length === 1 && page > 1 ? page - 1 : page;
-        setPage(newPage);
-        fetchImages(search, newPage);
-      } else {
-        setToast({ message: json.message || "Delete failed.", type: "error" });
-        setDeleteTarget(null);
-      }
-    } catch {
-      setToast({ message: "Delete failed.", type: "error" });
+      setToast({ message: "Gallery photo deleted successfully.", type: "success" });
+      setDeleteTarget(null);
+      setSelectedImage(null);
+      const newPage = images.length === 1 && page > 1 ? page - 1 : page;
+      setPage(newPage);
+      fetchImages(search, newPage);
+    } catch (e) {
+      setToast({ message: e instanceof Error ? e.message : "Delete failed.", type: "error" });
       setDeleteTarget(null);
     }
   };

--- a/next_webapp/src/app/[locale]/admin/use-cases/add/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/use-cases/add/page.tsx
@@ -311,6 +311,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { BookOpen, ImagePlus, Save, X } from "lucide-react";
 import AdminToast from "@/components/admin/AdminToast";
+import { apiFetch } from "@/lib/apiFetch";
 function getAuthHeaders() {
   const user = JSON.parse(localStorage.getItem("user") || "{}");
   const userId = user.userId ?? user.id ?? "";
@@ -348,11 +349,11 @@ export default function AddUseCasePage() {
   const notebookInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    fetch("/api/categories", { headers: getAuthHeaders() })
-      .then((r) => r.json())
+    apiFetch<{ success: boolean; data: any[] }>("/api/categories", { headers: getAuthHeaders() })
       .then((json) => {
         if (json.success) setCategories(json.data || []);
-      });
+      })
+      .catch(() => {}); // apiFetch already showed a toast; this was previously unhandled
   }, []);
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -369,12 +370,13 @@ export default function AddUseCasePage() {
     formData.append("folder", "usecases");
     formData.append("bucket", "usecase-images");
 
-    imageUploadPromiseRef.current = fetch("/api/upload", {
+    // Not silent: this upload happens in the background before the user
+    // hits Save, so a toast here is the only immediate feedback.
+    imageUploadPromiseRef.current = apiFetch<{ success: boolean; url?: string }>("/api/upload", {
       method: "POST",
       headers: authHeaders,
       body: formData,
     })
-      .then((r) => r.json())
       .then((json) => {
         setImageUploading(false);
         return json.success ? (json.url as string) : null;
@@ -444,7 +446,7 @@ export default function AddUseCasePage() {
         }
       }
 
-      const res = await fetch("/api/usecases", {
+      await apiFetch("/api/usecases", {
         method: "POST",
         headers: { "Content-Type": "application/json", ...authHeaders },
         body: JSON.stringify({
@@ -456,27 +458,21 @@ export default function AddUseCasePage() {
           created_by: userId,
           tags,
         }),
+        silent: true,
       });
-      const json = await res.json();
 
-      if (!json.success) {
-        const msg = json.message || json.error || "Failed to create use case.";
-        setError(msg);
-        setToast({ message: msg, type: "error" });
-        setSaving(false);
-        return;
-      }
-      
       setToast({
         message: "Use case added successfully.",
         type: "success",
       });
-      
+
       setTimeout(() => {
         router.push(`/${locale}/admin/use-cases`);
       }, 1000);
-    } catch {
-      setError("Failed to create use case.");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to create use case.";
+      setError(msg);
+      setToast({ message: msg, type: "error" });
       setSaving(false);
     }
   }

--- a/next_webapp/src/app/[locale]/admin/use-cases/edit/[id]/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/use-cases/edit/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { BookOpen, ImagePlus, Save, X, Plus } from "lucide-react";
+import { apiFetch } from "@/lib/apiFetch";
 
 function getAuthHeaders() {
   const user = JSON.parse(localStorage.getItem("user") || "{}");
@@ -56,15 +57,10 @@ export default function EditUseCasePage() {
     const headers = getAuthHeaders();
 
     Promise.all([
-      fetch(`/api/usecases/${id}`, { headers }).then((r) => r.json()),
-      fetch("/api/categories", { headers }).then((r) => r.json()),
+      apiFetch<any>(`/api/usecases/${id}`, { headers, silent: true }),
+      apiFetch<any>("/api/categories", { headers, silent: true }),
     ])
       .then(([ucJson, catJson]) => {
-        if (!ucJson.success) {
-          setFetchError(ucJson.message || ucJson.error || "Use case not found.");
-          return;
-        }
-
         const uc = ucJson.data;
 
         setTitle(uc.title || "");
@@ -88,7 +84,7 @@ export default function EditUseCasePage() {
           setCategories(catJson.data || []);
         }
       })
-      .catch(() => setFetchError("Failed to load use case."))
+      .catch((e) => setFetchError(e instanceof Error ? e.message : "Failed to load use case."))
       .finally(() => setFetchLoading(false));
   }, [id]);
 
@@ -107,12 +103,14 @@ export default function EditUseCasePage() {
     formData.append("folder", "usecases");
     formData.append("bucket", "usecase-images");
 
-    imageUploadPromiseRef.current = fetch("/api/upload", {
+    // Not silent: this upload happens in the background before the user
+    // hits Save, so a toast here is the only immediate feedback - the
+    // saveError banner below only shows up once they submit.
+    imageUploadPromiseRef.current = apiFetch<{ success: boolean; url?: string }>("/api/upload", {
       method: "POST",
       headers: authHeaders,
       body: formData,
     })
-      .then((r) => r.json())
       .then((json) => {
         setImageUploading(false);
         return json.success ? (json.url as string) : null;
@@ -196,7 +194,7 @@ export default function EditUseCasePage() {
 
       const updatedContent = notebookContent;
 
-      const res = await fetch(`/api/usecases/${id}`, {
+      await apiFetch(`/api/usecases/${id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -210,19 +208,12 @@ export default function EditUseCasePage() {
           ...(updatedContent !== undefined ? { content: updatedContent } : {}),
           tags,
         }),
+        silent: true,
       });
 
-      const json = await res.json();
-
-      if (!json.success) {
-        setSaveError(json.message || json.error || "Failed to update use case.");
-        setSaving(false);
-        return;
-      }
-
       router.push(`/${locale}/admin/use-cases`);
-    } catch {
-      setSaveError("Failed to update use case.");
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Failed to update use case.");
       setSaving(false);
     }
   }

--- a/next_webapp/src/app/[locale]/admin/use-cases/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/use-cases/page.tsx
@@ -8,6 +8,7 @@ import UseCaseTable from "./components/UseCaseTable";
 import ConfirmModal from "@/components/admin/ConfirmModal";
 import AdminToast from "@/components/admin/AdminToast";
 import Pagination from "@/components/Pagination";
+import { apiFetch } from "@/lib/apiFetch";
 
 function getAuthHeaders() {
   const user = JSON.parse(localStorage.getItem("user") || "{}");
@@ -41,10 +42,9 @@ const [toast, setToast] = useState<{ message: string; type: "success" | "error" 
 
   // Fetch all categories once for the dropdown
   useEffect(() => {
-    fetch("/api/categories?pageSize=100", { headers: getAuthHeaders() })
-      .then((r) => r.json())
+    apiFetch<{ success: boolean; data: any[] }>("/api/categories?pageSize=100", { headers: getAuthHeaders() })
       .then((json) => { if (json.success) setCategories(json.data || []); })
-      .catch(() => {});
+      .catch(() => {}); // apiFetch already showed a toast; this was previously a fully silent failure
   }, []);
 
   // Re-fetch use cases whenever page, search, or category filter changes
@@ -63,17 +63,15 @@ const [toast, setToast] = useState<{ message: string; type: "success" | "error" 
       if (search) params.set("search", search);
       if (selectedCategory !== "All") params.set("category_id", selectedCategory);
 
-      const res = await fetch(`/api/usecases?${params}`, { headers: getAuthHeaders() });
-      const json = await res.json();
-      if (json.success) {
-        setUsecases(json.data || []);
-        setTotalPages(json.pagination?.totalPages ?? 1);
-        setTotal(json.pagination?.total ?? 0);
-      } else {
-        setError(json.message || json.error || "Failed to load use cases.");
-      }
-    } catch {
-      setError("Failed to load data.");
+      const json = await apiFetch<{ success: boolean; data: any[]; pagination?: { total: number; totalPages: number } }>(
+        `/api/usecases?${params}`,
+        { headers: getAuthHeaders(), silent: true }
+      );
+      setUsecases(json.data || []);
+      setTotalPages(json.pagination?.totalPages ?? 1);
+      setTotal(json.pagination?.total ?? 0);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load data.");
     } finally {
       setLoading(false);
     }
@@ -97,31 +95,22 @@ const [toast, setToast] = useState<{ message: string; type: "success" | "error" 
     if (!deleteTarget) return;
   
     try {
-      const res = await fetch(`/api/usecases/${deleteTarget.id}`, {
+      await apiFetch(`/api/usecases/${deleteTarget.id}`, {
         method: "DELETE",
         headers: getAuthHeaders(),
+        silent: true,
       });
-  
-      const json = await res.json();
-  
-      if (!json.success) {
-        setToast({
-          message: json.message || json.error || "Failed to delete use case.",
-          type: "error",
-        });
-        return;
-      }
-  
+
       setToast({ message: "Use case deleted successfully.", type: "success" });
       setDeleteTarget(null);
-  
+
       if (usecases.length === 1 && page > 1) {
         setPage((p) => p - 1);
       } else {
         fetchUseCases();
       }
-    } catch {
-      setToast({ message: "Failed to delete use case.", type: "error" });
+    } catch (e) {
+      setToast({ message: e instanceof Error ? e.message : "Failed to delete use case.", type: "error" });
     }
   }
 

--- a/next_webapp/src/app/[locale]/blog/page.tsx
+++ b/next_webapp/src/app/[locale]/blog/page.tsx
@@ -100,6 +100,7 @@ import Footer from "@/components/Footer";
 import BlogCard from "@/components/BlogCard";
 import Pagination from "@/components/Pagination";
 import { Search } from "lucide-react";
+import { apiFetch } from "@/lib/apiFetch";
 
 const PAGE_SIZE = 9;
 type SearchMode = "title" | "content";
@@ -133,15 +134,16 @@ export default function BlogListingPage() {
         params.set("search", term);
         params.set("search_by", mode);
       }
-      const res = await fetch(`/api/home/blogs?${params}`);
-      const json = await res.json();
+      const json = await apiFetch<{ success: boolean; data: Blog[]; pagination?: { total: number; totalPages: number } }>(
+        `/api/home/blogs?${params}`
+      );
       if (json.success) {
         setBlogs(json.data ?? []);
         setTotal(json.pagination?.total ?? 0);
         setTotalPages(json.pagination?.totalPages ?? 1);
       }
     } catch (e) {
-      console.error(e);
+      console.error(e); // apiFetch already showed a toast
     } finally {
       setLoading(false);
     }

--- a/next_webapp/src/app/[locale]/change-password/page.tsx
+++ b/next_webapp/src/app/[locale]/change-password/page.tsx
@@ -4,6 +4,7 @@ import React, { Suspense, useState } from "react";
 import { useRouter, Link } from "@/i18n-navigation";
 import { useSearchParams } from "next/navigation";
 import { Eye, EyeOff } from "lucide-react";
+import { apiFetch, ApiError } from "@/lib/apiFetch";
 
 const ERROR_MESSAGES: Record<string, string> = {
   MISSING_FIELDS: "All fields are required.",
@@ -53,7 +54,7 @@ function ChangePasswordForm() {
     setLoading(true);
 
     try {
-      const response = await fetch("/api/auth/reset-password", {
+      await apiFetch("/api/auth/reset-password", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -62,26 +63,22 @@ function ChangePasswordForm() {
           new_password: newPassword,
           confirm_password: confirmNewPassword,
         }),
+        silent: true,
       });
 
-      const data = await response.json();
-
-      if (response.ok) {
-        localStorage.removeItem("token");
-        localStorage.removeItem("user");
-        setSuccess(true);
-        setTimeout(() => {
-          router.push("/login");
-        }, 2000);
-      } else {
-        setError(
-          ERROR_MESSAGES[data.code] ||
-            data.message ||
-            "Something went wrong. Please try again.",
-        );
-      }
-    } catch {
-      setError("Something went wrong. Please try again.");
+      localStorage.removeItem("token");
+      localStorage.removeItem("user");
+      setSuccess(true);
+      setTimeout(() => {
+        router.push("/login");
+      }, 2000);
+    } catch (err) {
+      const body = err instanceof ApiError ? (err.body as any) : null;
+      setError(
+        (body?.code && ERROR_MESSAGES[body.code]) ||
+          body?.message ||
+          (err instanceof Error ? err.message : "Something went wrong. Please try again."),
+      );
     } finally {
       setLoading(false);
     }

--- a/next_webapp/src/app/[locale]/contact/page.tsx
+++ b/next_webapp/src/app/[locale]/contact/page.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "../../../firebase/firebaseConfig";
 import { FiMail, FiMapPin, FiPhone, FiSend } from "react-icons/fi";
+import { apiFetch } from "@/lib/apiFetch";
 
 type FormField = {
   name: string;
@@ -190,7 +191,9 @@ const Contact = () => {
   try {
     setIsSubmitting(true);
 
-    const response = await fetch("/api/contact", {
+    // silent: true - this form already shows its own inline success/failure
+    // banner right below; a global toast on top would just be redundant.
+    await apiFetch("/api/contact", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -201,13 +204,8 @@ const Contact = () => {
         subject: formValues.subject,
         message: `Phone: ${formValues.phone}\n\n${formValues.message}`,
       }),
+      silent: true,
     });
-
-    const result = await response.json();
-
-    if (!response.ok || !result.success) {
-      throw new Error(result.message || "Failed to submit the form.");
-    }
 
     setSuccessMessage("Your message has been sent successfully.");
     setShowSuccess(true);

--- a/next_webapp/src/app/[locale]/forgot-password/page.tsx
+++ b/next_webapp/src/app/[locale]/forgot-password/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { Link } from "@/i18n-navigation";
+import { apiFetch, ApiError } from "@/lib/apiFetch";
 
 const ERROR_MESSAGES: Record<string, string> = {
   MISSING_FIELDS: "Please enter your email address.",
@@ -24,24 +25,21 @@ const ForgotPasswordPage = () => {
     setLoading(true);
 
     try {
-      const response = await fetch("/api/auth/forgot-password", {
+      await apiFetch("/api/auth/forgot-password", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email }),
+        silent: true,
       });
 
-      const data = await response.json();
-      if (response.ok) {
-        setSuccess(true);
-      } else {
-        setError(
-          ERROR_MESSAGES[data.code] ||
-            data.message ||
-            "Something went wrong. Please try again.",
-        );
-      }
-    } catch {
-      setError("Something went wrong. Please try again.");
+      setSuccess(true);
+    } catch (err) {
+      const body = err instanceof ApiError ? (err.body as any) : null;
+      setError(
+        (body?.code && ERROR_MESSAGES[body.code]) ||
+          body?.message ||
+          (err instanceof Error ? err.message : "Something went wrong. Please try again."),
+      );
     } finally {
       setLoading(false);
     }

--- a/next_webapp/src/app/[locale]/gallery/page.tsx
+++ b/next_webapp/src/app/[locale]/gallery/page.tsx
@@ -7,6 +7,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import Header from "../../../components/Header";
 import Footer from "../../../components/Footer";
 import Pagination from "@/components/Pagination";
+import { apiFetch } from "@/lib/apiFetch";
 
 const GLOW_COLORS = [
   "#22c55e",
@@ -46,15 +47,16 @@ export default function GalleryPage() {
         page: String(page),
         pageSize: String(ITEMS_PER_PAGE),
       });
-      const res = await fetch(`/api/home/gallery?${qs}`);
-      const json = await res.json();
+      const json = await apiFetch<{ success: boolean; data: ApiImage[]; pagination?: { total: number; totalPages: number } }>(
+        `/api/home/gallery?${qs}`
+      );
       if (json.success) {
         setImages(json.data ?? []);
         setTotal(json.pagination?.total ?? 0);
         setTotalPages(json.pagination?.totalPages ?? 1);
       }
     } catch (e) {
-      console.error("Failed to fetch gallery:", e);
+      console.error("Failed to fetch gallery:", e); // apiFetch already showed a toast
     } finally {
       setLoading(false);
     }

--- a/next_webapp/src/app/[locale]/layout.tsx
+++ b/next_webapp/src/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
+import { Toaster } from "sonner";
 
 export default async function LocaleLayout({
   children,
@@ -39,6 +40,7 @@ export default async function LocaleLayout({
       >
         <NextIntlClientProvider messages={messages}>
           <div className="flex-1 flex flex-col">{children}</div>
+          <Toaster richColors position="top-right" />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/next_webapp/src/app/[locale]/login/page.tsx
+++ b/next_webapp/src/app/[locale]/login/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { Link } from "@/i18n-navigation";
 import { Eye, EyeOff } from "lucide-react";
 import { storage } from "@/utils/storage";
+import { apiFetch, ApiError } from "@/lib/apiFetch";
 
 function LoginForm() {
     const t = useTranslations("login");
@@ -38,18 +39,12 @@ function LoginForm() {
             setIsSubmitting(true);
             setError("");
 
-            const response = await fetch("/api/auth/login", {
+            const result = await apiFetch<any>("/api/auth/login", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ email, password }),
+                silent: true,
             });
-
-            const result = await response.json();
-
-            if (!response.ok) {
-                setError(result.message || "Login failed");
-                return;
-            }
 
             storage.setItem("userId", result.data.userId.toString());
             storage.setItem("user", JSON.stringify(result.data));
@@ -62,7 +57,8 @@ function LoginForm() {
             }
         } catch (err) {
             console.error("Login error:", err);
-            setError("Something went wrong. Please try again.");
+            const body = err instanceof ApiError ? (err.body as any) : null;
+            setError(body?.message || (err instanceof Error ? err.message : "Login failed"));
         } finally {
             setIsSubmitting(false);
         }

--- a/next_webapp/src/app/[locale]/profile/page.jsx
+++ b/next_webapp/src/app/[locale]/profile/page.jsx
@@ -5,6 +5,7 @@ import Footer from "../../../components/Footer";
 import { useState, useEffect } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { Camera, User, Mail, Phone, MapPin, Calendar, Save } from "lucide-react";
+import { apiFetch, ApiError } from "@/lib/apiFetch";
 
 const Profile = () => {
   const router = useRouter();
@@ -96,44 +97,42 @@ const Profile = () => {
         return;
       }
 
-      const response = await fetch("/api/profile", {
+      const result = await apiFetch("/api/profile", {
         method: "GET",
         headers: {
           "x-user-id": userId,
           "Authorization": `Bearer ${token}`,
         },
+        silent: true,
       });
 
-      console.log("Profile API response status:", response.status);
-      const result = await response.json();
       console.log("Profile API response:", result);
 
-      if (result.success && result.data) {
-        setFormData((prev) => ({
-          ...prev,
-          first_name: result.data.first_name || "",
-          last_name: result.data.last_name || "",
-          age: result.data.age || "",
-          gender: result.data.gender || "",
-          profile_img: result.data.profile_img || "",
-          email: result.data.email || "",
-        }));
+      setFormData((prev) => ({
+        ...prev,
+        first_name: result.data.first_name || "",
+        last_name: result.data.last_name || "",
+        age: result.data.age || "",
+        gender: result.data.gender || "",
+        profile_img: result.data.profile_img || "",
+        email: result.data.email || "",
+      }));
 
-        // Set profile image preview if available
-        if (result.data.profile_img) {
-          setProfileImage(result.data.profile_img);
-        }
-
-        console.log("Profile data loaded successfully:", result.data);
-      } else {
-        console.error("Failed to fetch profile - success is false or no data:", result);
-        if (result.message === "Unauthorised") {
-          setErrors({ form: "You are not authorized. Please login again." });
-        }
+      // Set profile image preview if available
+      if (result.data.profile_img) {
+        setProfileImage(result.data.profile_img);
       }
+
+      console.log("Profile data loaded successfully:", result.data);
     } catch (error) {
       console.error("Failed to fetch profile:", error);
-      setErrors({ form: "Failed to load profile. Please try again." });
+      // Note: previously only an "Unauthorised" failure surfaced any message here;
+      // every other failure was silently dropped. Now shows a message either way.
+      if (error instanceof Error && error.message === "Unauthorised") {
+        setErrors({ form: "You are not authorized. Please login again." });
+      } else {
+        setErrors({ form: "Failed to load profile. Please try again." });
+      }
     } finally {
       setFetchingProfile(false);
     }
@@ -172,30 +171,24 @@ const Profile = () => {
       formDataForUpload.append("userId", userId);
 
       // Upload to API endpoint (we'll need to create this)
-      const uploadResponse = await fetch("/api/profile/upload-image", {
+      const uploadResult = await apiFetch("/api/profile/upload-image", {
         method: "POST",
         headers: {
           "x-user-id": userId,
           "Authorization": `Bearer ${token}`,
         },
         body: formDataForUpload,
+        silent: true,
       });
 
-      const uploadResult = await uploadResponse.json();
-
-      if (uploadResult.success && uploadResult.imageUrl) {
-        setFormData((prev) => ({
-          ...prev,
-          profile_img: uploadResult.imageUrl,
-        }));
-        console.log("Image uploaded successfully:", uploadResult.imageUrl);
-      } else {
-        setErrors({ form: uploadResult.message || "Failed to upload image" });
-        setProfileImage(null);
-      }
+      setFormData((prev) => ({
+        ...prev,
+        profile_img: uploadResult.imageUrl,
+      }));
+      console.log("Image uploaded successfully:", uploadResult.imageUrl);
     } catch (error) {
       console.error("Image upload error:", error);
-      setErrors({ form: "Failed to upload image. Please try again." });
+      setErrors({ form: error instanceof Error ? error.message : "Failed to upload image. Please try again." });
       setProfileImage(null);
     }
   };
@@ -229,7 +222,7 @@ const Profile = () => {
         payload[key] === undefined && delete payload[key]
       );
 
-      const response = await fetch("/api/profile", {
+      await apiFetch("/api/profile", {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -237,27 +230,23 @@ const Profile = () => {
           "Authorization": `Bearer ${token}`,
         },
         body: JSON.stringify(payload),
+        silent: true,
       });
 
-      const result = await response.json();
-
-      if (result.success) {
-        setSuccessMessage("Profile updated successfully!");
-        setTimeout(() => setSuccessMessage(""), 5000);
-      } else {
-        if (result.errors && Array.isArray(result.errors)) {
-          const errorMap = {};
-          result.errors.forEach((err) => {
-            errorMap[err.field] = err.message;
-          });
-          setErrors(errorMap);
-        } else {
-          setErrors({ form: result.message });
-        }
-      }
+      setSuccessMessage("Profile updated successfully!");
+      setTimeout(() => setSuccessMessage(""), 5000);
     } catch (error) {
       console.error("Error updating profile:", error);
-      setErrors({ form: "Failed to update profile. Please try again." });
+      const body = error instanceof ApiError ? error.body : null;
+      if (body?.errors && Array.isArray(body.errors)) {
+        const errorMap = {};
+        body.errors.forEach((err) => {
+          errorMap[err.field] = err.message;
+        });
+        setErrors(errorMap);
+      } else {
+        setErrors({ form: error instanceof Error ? error.message : "Failed to update profile. Please try again." });
+      }
     } finally {
       setLoading(false);
     }

--- a/next_webapp/src/app/[locale]/search/page.tsx
+++ b/next_webapp/src/app/[locale]/search/page.tsx
@@ -7,6 +7,7 @@ import Footer from "@/components/Footer";
 import SearchFilter from "../../../components/SearchFilter";
 import SearchResults from "../../../components/SearchResults";
 import Pagination from "@/components/Pagination";
+import { apiFetch } from "@/lib/apiFetch";
 
 interface SearchResult {
     id: number;
@@ -56,12 +57,11 @@ export default function SearchPage() {
             setError(false);
             try {
                 const params = new URLSearchParams(searchParams.toString());
-                const response = await fetch(`/api/search?${params.toString()}`);
-                const data = await response.json();
+                const data = await apiFetch<{ success: boolean; data: SearchData }>(`/api/search?${params.toString()}`);
                 if (data.success) setSearchResults(data.data);
                 else setError(true);
             } catch {
-                setError(true);
+                setError(true); // apiFetch already showed a toast
             } finally {
                 setLoading(false);
             }

--- a/next_webapp/src/app/[locale]/signup/page.tsx
+++ b/next_webapp/src/app/[locale]/signup/page.tsx
@@ -5,6 +5,7 @@ import { useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
 import { Link } from "@/i18n-navigation";
 import { Eye, EyeOff } from "lucide-react";
+import { apiFetch, ApiError } from "@/lib/apiFetch";
 
 const SignUpPage = () => {
   const router = useRouter();
@@ -85,20 +86,18 @@ const SignUpPage = () => {
 
     try {
       setIsSubmitting(true);
-      const response = await fetch("/api/auth/signup", {
+      await apiFetch("/api/auth/signup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(form),
+        silent: true,
       });
-      const data = await response.json();
-      if (response.ok) {
-        setSuccessMessage("Account created! Redirecting to login...");
-        setTimeout(() => router.push(`/${locale}/login`), 1500);
-      } else {
-        setErrorMessage(data.message || "Sign-up failed. Please try again.");
-      }
-    } catch {
-      setErrorMessage("Something went wrong. Please try again later.");
+
+      setSuccessMessage("Account created! Redirecting to login...");
+      setTimeout(() => router.push(`/${locale}/login`), 1500);
+    } catch (err) {
+      const body = err instanceof ApiError ? (err.body as any) : null;
+      setErrorMessage(body?.message || (err instanceof Error ? err.message : "Sign-up failed. Please try again."));
     } finally {
       setIsSubmitting(false);
     }

--- a/next_webapp/src/app/[locale]/statistics/page.tsx
+++ b/next_webapp/src/app/[locale]/statistics/page.tsx
@@ -16,6 +16,7 @@ import { useEffect, useState } from "react";
 import { Bar } from "react-chartjs-2";
 import Footer from "../../../components/Footer";
 import Header from "../../../components/Header";
+import { apiFetch } from "@/lib/apiFetch";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
@@ -52,13 +53,11 @@ const Statistics = () => {
   }, [tagFilter, trimesterFilter, caseStudies]);
 
   async function searchUseCases(searchParams: SearchParams) {
-    const response = await fetch("/api/search-use-cases", {
+    return apiFetch<{ filteredStudies: CaseStudy[] }>("/api/search-use-cases", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(searchParams),
     });
-    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-    return await response.json();
   }
 
   const getStats = (caseStudiesArray: CaseStudy[]) => {

--- a/next_webapp/src/app/[locale]/usecases/[id]/page.tsx
+++ b/next_webapp/src/app/[locale]/usecases/[id]/page.tsx
@@ -49,13 +49,11 @@ const UseCasePage: React.FC = () => {
     if (!id || !useCase?.content_file_id) return;
 
     setContentLoading(true);
-    // Not migrated to apiFetch: this endpoint returns the raw notebook text,
-    // not the app's usual {success, data} JSON envelope, and apiFetch always
-    // parses the response as JSON.
-    fetch(`/api/usecases/${id}/content`)
-      .then((r) => (r.ok ? r.text() : null))
+    // This endpoint returns the raw notebook text, not the app's usual
+    // {success, data} JSON envelope, so use apiFetch's text mode.
+    apiFetch<string>(`/api/usecases/${id}/content`, { responseType: "text" })
       .then(setNotebookText)
-      .catch(() => setNotebookText(null))
+      .catch(() => setNotebookText(null)) // apiFetch already showed a toast
       .finally(() => setContentLoading(false));
   }, [id, useCase?.content_file_id]);
 

--- a/next_webapp/src/app/[locale]/usecases/[id]/page.tsx
+++ b/next_webapp/src/app/[locale]/usecases/[id]/page.tsx
@@ -8,6 +8,8 @@ import Image from "next/image";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import NotebookRenderer from "@/components/NotebookRenderer";
+import { apiFetch } from "@/lib/apiFetch";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const UseCasePage: React.FC = () => {
   const params = useParams();
@@ -27,8 +29,7 @@ const UseCasePage: React.FC = () => {
   useEffect(() => {
     if (!id) return;
 
-    fetch(`/api/usecases/${id}`)
-      .then((r) => r.json())
+    apiFetch<{ success: boolean; data: any }>(`/api/usecases/${id}`)
       .then((ucJson) => {
         if (!ucJson.success) {
           setNotFound(true);
@@ -40,7 +41,7 @@ const UseCasePage: React.FC = () => {
         // so there's no separate join/lookup call needed here any more.
         setTags((ucJson.data.tags ?? []).map((t: any) => t.name));
       })
-      .catch(() => setNotFound(true))
+      .catch(() => setNotFound(true)) // apiFetch already showed a toast
       .finally(() => setLoading(false));
   }, [id]);
 
@@ -48,6 +49,9 @@ const UseCasePage: React.FC = () => {
     if (!id || !useCase?.content_file_id) return;
 
     setContentLoading(true);
+    // Not migrated to apiFetch: this endpoint returns the raw notebook text,
+    // not the app's usual {success, data} JSON envelope, and apiFetch always
+    // parses the response as JSON.
     fetch(`/api/usecases/${id}/content`)
       .then((r) => (r.ok ? r.text() : null))
       .then(setNotebookText)
@@ -157,7 +161,9 @@ const UseCasePage: React.FC = () => {
                 />
               ) : (
                 <div className="mb-8 rounded-2xl border border-gray-200 bg-white p-6 text-gray-800 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 [&_*]:dark:text-gray-200">
-                  <NotebookRenderer content={notebookText} />
+                  <ErrorBoundary name="NotebookRenderer">
+                    <NotebookRenderer content={notebookText} />
+                  </ErrorBoundary>
                 </div>
               )
             ) : (

--- a/next_webapp/src/app/[locale]/usecases/page.tsx
+++ b/next_webapp/src/app/[locale]/usecases/page.tsx
@@ -143,6 +143,7 @@ import SearchBar, { LocalSearchMode } from "./searchbar";
 import PreviewComponent from "./preview";
 import { CATEGORY, CaseStudy } from "../../types";
 import Tooglebutton from "../Tooglebutton/Tooglebutton";
+import { apiFetch } from "@/lib/apiFetch";
 
 const PAGE_SIZE = 9;
 
@@ -200,8 +201,9 @@ const UseCases: React.FC = () => {
 					}
 				}
 
-				const res = await fetch(`/api/usecases?${params}`);
-				const json = await res.json();
+				const json = await apiFetch<{ success: boolean; data: any[]; pagination?: { total: number; totalPages: number } }>(
+					`/api/usecases?${params}`
+				);
 
 				if (json.success) {
 					const mapped: CaseStudy[] = (json.data || []).map((u: any) => ({
@@ -220,7 +222,7 @@ const UseCases: React.FC = () => {
 					setTotalPages(json.pagination?.totalPages ?? 1);
 				}
 			} catch (e) {
-				console.error(e);
+				console.error(e); // apiFetch already showed a toast
 			} finally {
 				setLoading(false);
 			}

--- a/next_webapp/src/app/chatbot/chatbot.tsx
+++ b/next_webapp/src/app/chatbot/chatbot.tsx
@@ -7,6 +7,7 @@ import enMessages from "./en.json";
 import "./chatbot.css";
 import { processInput } from "./nlp/nlpProcessor";
 import { CaseStudy } from "@/app/types";
+import { apiFetch } from "@/lib/apiFetch";
 
 type Message = {
   content: React.ReactNode;
@@ -149,12 +150,14 @@ const Chatbot = () => {
 
   const fetchUseCasesFromAPI = async (searchTerm: string, searchMode = "TITLE") => {
     try {
-      const response = await fetch("/api/search-use-cases", {
+      // silent: true - a failed background lookup here just falls back to
+      // the chatbot's own "couldn't find that" reply, not worth a toast.
+      const data = await apiFetch<{ filteredStudies: CaseStudy[] }>("/api/search-use-cases", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ category: "", searchMode, searchTerm }),
+        silent: true,
       });
-      const data = await response.json();
       return data.filteredStudies;
     } catch (error) {
       console.error("Error fetching use cases:", error);

--- a/next_webapp/src/app/chatbot/helpers/usecases.ts
+++ b/next_webapp/src/app/chatbot/helpers/usecases.ts
@@ -1,14 +1,20 @@
+import { apiFetch } from "@/lib/apiFetch";
+
 export interface LiveUseCase {
   id: number;
   name: string;
   description: string;
-  htmlPath: string;   
+  htmlPath: string;
 }
 
 export async function searchUseCases(query: string): Promise<LiveUseCase[]> {
-  const res = await fetch(`/api/usecases?q=${encodeURIComponent(query)}`);
-  if (!res.ok) return [];
-  return (await res.json()) as LiveUseCase[];
+  try {
+    // silent: true - this is a lookup helper; callers expect a plain
+    // array back and fall back to [] on failure, not a toast.
+    return await apiFetch<LiveUseCase[]>(`/api/usecases?q=${encodeURIComponent(query)}`, { silent: true });
+  } catch {
+    return [];
+  }
 }
 
 

--- a/next_webapp/src/components/BLogSInglePage.tsx
+++ b/next_webapp/src/components/BLogSInglePage.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import { Link } from "@/i18n-navigation";
 import Image from "next/image";
+import { apiFetch } from "@/lib/apiFetch";
 
 interface Blog {
   id: number;
@@ -42,23 +43,17 @@ const BlogSinglePage: React.FC<{ id: string }> = ({ id }) => {
     const fetchBlog = async () => {
       setLoading(true);
       try {
-        const res = await fetch(`/api/home/blogs/${id}`);
-        const json = await res.json();
-
-        if (!res.ok || !json.success) {
-          setNotFound(true);
-          return;
-        }
+        const json = await apiFetch<{ success: boolean; data: Blog }>(`/api/home/blogs/${id}`);
 
         setBlog(json.data);
 
         // Random recommendations (server pools up to 800, shuffles, returns 3)
-        const relRes = await fetch(
-          `/api/home/blogs?recommend=1&excludeId=${encodeURIComponent(String(json.data.id))}&take=3`
+        const relJson = await apiFetch<{ success: boolean; data: RelatedBlog[] }>(
+          `/api/home/blogs?recommend=1&excludeId=${encodeURIComponent(String(json.data.id))}&take=3`,
+          { silent: true } // recommendations are non-critical; fail quietly rather than toast
         );
-        const relJson = await relRes.json();
         if (relJson.success && Array.isArray(relJson.data)) {
-          setRelated(relJson.data as RelatedBlog[]);
+          setRelated(relJson.data);
         }
       } catch (e) {
         console.error(e);

--- a/next_webapp/src/components/Blogpage.tsx
+++ b/next_webapp/src/components/Blogpage.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "@/i18n-navigation";
 import Image from "next/image";
+import { apiFetch } from "@/lib/apiFetch";
 
 interface Blog {
   id: number;
@@ -16,10 +17,9 @@ const BlogPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("/api/home/blogs?page=1&pageSize=3")
-      .then((r) => r.json())
+    apiFetch<{ success: boolean; data: Blog[] }>("/api/home/blogs?page=1&pageSize=3")
       .then((json) => { if (json.success) setBlogs(json.data ?? []); })
-      .catch(() => {})
+      .catch(() => {}) // apiFetch already showed a toast; just fall back to the empty state below
       .finally(() => setLoading(false));
   }, []);
 

--- a/next_webapp/src/components/ContactUsSection.tsx
+++ b/next_webapp/src/components/ContactUsSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Mail, MapPin, Phone } from "lucide-react";
+import { apiFetch } from "@/lib/apiFetch";
 
 type FormDataType = {
   fullName: string;
@@ -114,7 +115,9 @@ export default function ContactUsSection() {
     try {
       setIsSubmitting(true);
 
-      const response = await fetch("/api/contact", {
+      // silent: true - this form already shows its own inline success/failure
+      // banner right below; a global toast on top would just be redundant.
+      await apiFetch("/api/contact", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -125,13 +128,8 @@ export default function ContactUsSection() {
           subject: formData.subject,
           message: formData.message,
         }),
+        silent: true,
       });
-
-      const result = await response.json();
-
-      if (!response.ok || !result.success) {
-        throw new Error(result.message || "Failed to submit the form.");
-      }
 
       setSuccessMessage("Your message has been sent successfully.");
       setFormData({

--- a/next_webapp/src/components/Dashboard.tsx
+++ b/next_webapp/src/components/Dashboard.tsx
@@ -917,8 +917,10 @@ const Dashboard = () => {
 					params.set("search", searchTerm.trim());
 					params.set("search_by", searchMode);
 				}
-				const res = await fetch(`/api/usecases?${params}`);
-				const json = await res.json();
+				const json = await apiFetch<{ success: boolean; data?: any[] }>(
+					`/api/usecases?${params}`,
+					{ silent: true }
+				);
 				if (json.success) {
 					setFilteredCaseStudies(
 						(json.data || []).map((u: any) => ({

--- a/next_webapp/src/components/Dashboard.tsx
+++ b/next_webapp/src/components/Dashboard.tsx
@@ -11,6 +11,7 @@ import HeroSlider, { HERO_SLIDES } from "@/components/HeroSlider";
 import { useTranslations } from "next-intl";
 import { CaseStudy, CATEGORY, SEARCH_MODE, SearchParams } from "@/app/types";
 import { useEffect, useState, useRef } from "react";
+import { apiFetch } from "@/lib/apiFetch";
 import {
 	ArrowRight,
 	Play,
@@ -940,18 +941,16 @@ const Dashboard = () => {
 	}, [searchTerm, searchMode]);
 
 	useEffect(() => {
-		fetch("/api/usecases/recent")
-			.then((r) => r.json())
-			.then((json) => { if (json.success) setRecentUseCases(json.data || []); })
-			.catch(() => {})
+		apiFetch<{ success: boolean; data: any[] }>("/api/usecases/recent")
+			.then((json) => { if (json.success) setRecentUseCases(json.data ?? []); })
+			.catch(() => {}) // apiFetch already showed a toast; just fall back to the empty state below
 			.finally(() => setRecentLoading(false));
 	}, []);
 
 	useEffect(() => {
-		fetch("/api/home/categories")
-			.then((r) => r.json())
-			.then((json) => { if (json.success) setHomeCategories(json.data || []); })
-			.catch(() => {});
+		apiFetch<{ success: boolean; data: any[] }>("/api/home/categories")
+			.then((json) => { if (json.success) setHomeCategories(json.data ?? []); })
+			.catch(() => {}); // apiFetch already showed a toast; just fall back to the empty state below
 	}, []);
 
 	// Add click outside handler

--- a/next_webapp/src/components/ErrorBoundary.tsx
+++ b/next_webapp/src/components/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React from "react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  /** Optional custom fallback. Defaults to a generic inline message. */
+  fallback?: React.ReactNode;
+  /** Optional label included in the console log, to identify which boundary tripped. */
+  name?: string;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Catches render-time errors thrown by its child subtree (e.g. a widget
+ * fed malformed data) so that one crashing section doesn't take down the
+ * rest of the page. This is a plain React error boundary and can only be
+ * a class component - React has no hook equivalent.
+ *
+ * Not a replacement for Next.js's route-level `error.tsx` (e.g.
+ * src/app/[locale]/error.tsx), which already handles a whole route
+ * segment crashing. Use this to wrap a specific risky section - a chart,
+ * a map embed, rendered third-party/user content - inside an otherwise
+ * healthy page.
+ */
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error(`[ErrorBoundary${this.props.name ? `:${this.props.name}` : ""}]`, error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback ?? (
+          <div className="flex min-h-[120px] items-center justify-center rounded-2xl border border-dashed border-red-200 bg-red-50 px-6 py-8 text-center dark:border-red-900 dark:bg-red-950/20">
+            <p className="text-sm font-medium text-red-500 dark:text-red-400">
+              Something went wrong displaying this section.
+            </p>
+          </div>
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/next_webapp/src/components/Insights.tsx
+++ b/next_webapp/src/components/Insights.tsx
@@ -1,6 +1,7 @@
 ﻿"use client";
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
+import { apiFetch } from "@/lib/apiFetch";
 
 
 const categoryStyles: Record<string, { badge: string; border: string }> = {
@@ -24,10 +25,9 @@ const Insights: React.FC = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("/api/home/categories")
-      .then((r) => r.json())
-      .then((json) => { if (json.success) setCategories(json.data || []); })
-      .catch(() => {})
+    apiFetch<{ success: boolean; data: any[] }>("/api/home/categories")
+      .then((json) => { if (json.success) setCategories(json.data ?? []); })
+      .catch(() => {}) // apiFetch already showed a toast; just fall back to the empty state below
       .finally(() => setLoading(false));
   }, []);
 

--- a/next_webapp/src/components/SearchFilter.tsx
+++ b/next_webapp/src/components/SearchFilter.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { apiFetch } from '@/lib/apiFetch';
 
 // Matches the Mongoose Category schema (src/models/mongoose/Category.ts).
 // No slug, color, or icon fields exist on the schema.
@@ -47,13 +48,12 @@ export default function SearchFilter({ onFilterChange }: SearchFilterProps) {
 
     const fetchCategories = async () => {
         try {
-            const response = await fetch('/api/categories');
-            const data = await response.json();
+            const data = await apiFetch<{ success: boolean; data: Category[] }>('/api/categories');
             if (data.success) {
                 setCategories(data.data);
             }
         } catch (error) {
-            console.error('Error fetching categories:', error);
+            console.error('Error fetching categories:', error); // apiFetch already showed a toast
         }
     };
 

--- a/next_webapp/src/components/admin/AdminRecentActivity.tsx
+++ b/next_webapp/src/components/admin/AdminRecentActivity.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { apiFetch } from "@/lib/apiFetch";
 
 interface ActivityEntry {
   id: number;
@@ -36,12 +37,11 @@ export default function AdminRecentActivity() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("/api/admin/activity-history?pageSize=5", { headers: authHeaders() })
-      .then((r) => r.json())
+    apiFetch<{ success: boolean; data: ActivityEntry[] }>("/api/admin/activity-history?pageSize=5", { headers: authHeaders() })
       .then((json) => {
         if (json.success) setEntries(json.data || []);
       })
-      .catch(() => {})
+      .catch(() => {}) // apiFetch already showed a toast; this was previously a fully silent failure
       .finally(() => setLoading(false));
   }, []);
 

--- a/next_webapp/src/lib/apiFetch.ts
+++ b/next_webapp/src/lib/apiFetch.ts
@@ -1,0 +1,86 @@
+import { toast } from "sonner";
+
+/**
+ * Thrown by apiFetch for any failed request: network failure, non-2xx
+ * HTTP status, or a 2xx response whose JSON body has `success: false`.
+ *
+ * `status` is 0 for network-level failures (offline, DNS, CORS, server
+ * unreachable) where no HTTP response was ever received.
+ */
+export class ApiError extends Error {
+  status: number;
+  body: unknown;
+
+  constructor(message: string, status: number, body?: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+interface ApiFetchOptions extends RequestInit {
+  /**
+   * Suppress the automatic error toast for this call. Use when the
+   * caller wants to render its own inline error UI instead (e.g. a
+   * form field) rather than a global notification. The call still
+   * throws ApiError on failure either way.
+   */
+  silent?: boolean;
+}
+
+/**
+ * fetch() wrapper that centralizes error handling for API calls:
+ *  - Network failures (server down, offline, CORS, timeouts) are caught
+ *    and normalized instead of throwing a raw TypeError.
+ *  - Non-2xx HTTP responses are treated as failures.
+ *  - This app's API routes return `{ success, message, data }`; a 2xx
+ *    response with `success: false` is also treated as a failure.
+ *  - On any failure, a toast is shown (unless `silent`) and an
+ *    `ApiError` is thrown so callers can still `catch` to update local
+ *    state (loading flags, fallback UI, etc.) without re-implementing
+ *    error messaging themselves.
+ *
+ * On success, resolves with the parsed JSON body (the full response
+ * envelope - callers destructure `.data` as needed, matching this
+ * app's existing `{ success, data }` API shape).
+ */
+export async function apiFetch<T = unknown>(
+  input: string,
+  options: ApiFetchOptions = {}
+): Promise<T> {
+  const { silent, ...init } = options;
+
+  let res: Response;
+  try {
+    res = await fetch(input, init);
+  } catch {
+    const message = "Network error - please check your connection and try again.";
+    if (!silent) toast.error(message);
+    throw new ApiError(message, 0);
+  }
+
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    // No/invalid JSON body. Fine for e.g. 204 No Content; only a
+    // problem below if the response also wasn't ok.
+  }
+
+  const success =
+    typeof body === "object" && body !== null && "success" in body
+      ? (body as { success?: unknown }).success !== false
+      : true;
+
+  if (!res.ok || !success) {
+    const message =
+      (typeof body === "object" && body !== null && "message" in body
+        ? String((body as { message?: unknown }).message)
+        : undefined) || `Request failed (${res.status})`;
+    if (!silent) toast.error(message);
+    throw new ApiError(message, res.status, body);
+  }
+
+  return body as T;
+}

--- a/next_webapp/src/lib/apiFetch.ts
+++ b/next_webapp/src/lib/apiFetch.ts
@@ -27,6 +27,14 @@ interface ApiFetchOptions extends RequestInit {
    * throws ApiError on failure either way.
    */
   silent?: boolean;
+  /**
+   * How to parse a successful response body. Defaults to "json" to
+   * preserve existing behavior. Use "text" for endpoints that return
+   * a raw body (e.g. file/notebook content) rather than this app's
+   * usual `{ success, data }` JSON envelope. Error handling (toast on
+   * failure, ApiError on non-2xx) is the same either way.
+   */
+  responseType?: "json" | "text";
 }
 
 /**
@@ -43,13 +51,15 @@ interface ApiFetchOptions extends RequestInit {
  *
  * On success, resolves with the parsed JSON body (the full response
  * envelope - callers destructure `.data` as needed, matching this
- * app's existing `{ success, data }` API shape).
+ * app's existing `{ success, data }` API shape). Pass
+ * `responseType: "text"` for endpoints that return a raw body instead
+ * (e.g. file/notebook content) to get the raw text back unparsed.
  */
 export async function apiFetch<T = unknown>(
   input: string,
   options: ApiFetchOptions = {}
 ): Promise<T> {
-  const { silent, ...init } = options;
+  const { silent, responseType = "json", ...init } = options;
 
   let res: Response;
   try {
@@ -58,6 +68,16 @@ export async function apiFetch<T = unknown>(
     const message = "Network error - please check your connection and try again.";
     if (!silent) toast.error(message);
     throw new ApiError(message, 0);
+  }
+
+  if (responseType === "text") {
+    const text = await res.text().catch(() => "");
+    if (!res.ok) {
+      const message = `Request failed (${res.status})`;
+      if (!silent) toast.error(message);
+      throw new ApiError(message, res.status, text);
+    }
+    return text as unknown as T;
   }
 
   let body: unknown = null;


### PR DESCRIPTION
Implemented global API error handling for Sprint 3.

- Added apiFetch() a fetch() wrapper that catches failures and 
  shows a toast notification (sonner). Used instead of Axios 
  interceptors since the app barely uses Axios.
- Added ErrorBoundary wired around NotebookRenderer to catch 
  render-time crashes.
- Migrated 39 files (read-only pages, admin CRUD, auth flows) to use 
  apiFetch instead of raw fetch() so failures no longer fail silently.
- Auth and contact forms use silent mode since they already show 
  their own error messages so  those will stay unchanged.
- Fixed one pre-existing bug along the way: profile/page.jsx only 
  showed errors for "Unauthorised" failures before now shows errors 
  for any failure.