### PR TITLE
WD: fix(profile): fix input background, text color, and dropdown styling …

### DIFF
--- a/next_webapp/src/app/[locale]/profile/page.jsx
+++ b/next_webapp/src/app/[locale]/profile/page.jsx
@@ -278,7 +278,7 @@ const Profile = () => {
             </p>
           </div>
 
-          <div className="bg-white dark:bg-[#1f2a30] border border-gray-200 dark:border-white/10 rounded-2xl shadow-md p-6 md:p-8">
+          <div className="bg-white dark:bg-[#1f2a30] border border-gray-200 dark:border-gray-700 rounded-2xl shadow-md p-6 md:p-8">
             {fetchingProfile && (
               <div className="bg-blue-100 dark:bg-blue-900 border border-blue-400 dark:border-blue-500 text-blue-800 dark:text-blue-100 px-4 py-3 rounded-lg mb-6">
                 Loading your profile data...
@@ -299,7 +299,7 @@ const Profile = () => {
 
             <form onSubmit={handleSubmit} className="space-y-8" disabled={fetchingProfile}>
               <div className="flex flex-col items-center justify-center">
-                <div className="relative w-32 h-32 rounded-full overflow-hidden border-4 border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 flex items-center justify-center">
+                <div className="relative w-32 h-32 rounded-full overflow-hidden border-4 border-gray-200 dark:border-gray-700 bg-white dark:bg-[#263238] flex items-center justify-center">
                   {profileImage ? (
                     <img
                       src={profileImage}
@@ -307,7 +307,7 @@ const Profile = () => {
                       className="w-full h-full object-cover"
                     />
                   ) : (
-                    <User className="w-14 h-14 text-gray-400" />
+                    <User className="w-14 h-14 text-gray-400 dark:text-gray-400" />
                   )}
 
                   <label className="absolute bottom-1 right-7 bg-green-600 hover:bg-green-700 text-white p-2 rounded-full cursor-pointer transition">
@@ -327,24 +327,24 @@ const Profile = () => {
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
                 <div>
-                  <label className="block mb-2 text-sm font-medium text-black dark:text-white">
+                  <label className="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
                     First Name
                   </label>
                   <div
-                    className={`flex items-center bg-white dark:bg-white/5 border rounded-xl px-3 ${
+                    className={`flex items-center bg-white dark:bg-[#263238] border rounded-xl px-3 transition-colors ${
                       errors.first_name
                         ? "border-red-500"
-                        : "border-gray-300 dark:border-white/10"
+                        : "border-gray-300 dark:border-gray-600 focus-within:border-green-500 dark:focus-within:border-green-500"
                     }`}
                   >
-                    <User size={18} className="text-gray-400 mr-2" />
+                    <User size={18} className="text-gray-400 dark:text-gray-400 mr-2 shrink-0" />
                     <input
                       type="text"
                       name="first_name"
                       value={formData.first_name}
                       onChange={handleChange}
                       placeholder="Enter your first name"
-                      className="w-full bg-transparent outline-none py-3 text-black dark:text-white placeholder-gray-500"
+                      className="w-full bg-transparent outline-none py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400"
                     />
                   </div>
                   {errors.first_name && (
@@ -353,24 +353,24 @@ const Profile = () => {
                 </div>
 
                 <div>
-                  <label className="block mb-2 text-sm font-medium text-black dark:text-white">
+                  <label className="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
                     Last Name
                   </label>
                   <div
-                    className={`flex items-center bg-white dark:bg-white/5 border rounded-xl px-3 ${
+                    className={`flex items-center bg-white dark:bg-[#263238] border rounded-xl px-3 transition-colors ${
                       errors.last_name
                         ? "border-red-500"
-                        : "border-gray-300 dark:border-white/10"
+                        : "border-gray-300 dark:border-gray-600 focus-within:border-green-500 dark:focus-within:border-green-500"
                     }`}
                   >
-                    <User size={18} className="text-gray-400 mr-2" />
+                    <User size={18} className="text-gray-400 dark:text-gray-400 mr-2 shrink-0" />
                     <input
                       type="text"
                       name="last_name"
                       value={formData.last_name}
                       onChange={handleChange}
                       placeholder="Enter your last name"
-                      className="w-full bg-transparent outline-none py-3 text-black dark:text-white placeholder-gray-500"
+                      className="w-full bg-transparent outline-none py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400"
                     />
                   </div>
                   {errors.last_name && (
@@ -379,24 +379,24 @@ const Profile = () => {
                 </div>
 
                 <div>
-                  <label className="block mb-2 text-sm font-medium text-black dark:text-white">
+                  <label className="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
                     Age
                   </label>
                   <div
-                    className={`flex items-center bg-white dark:bg-white/5 border rounded-xl px-3 ${
+                    className={`flex items-center bg-white dark:bg-[#263238] border rounded-xl px-3 transition-colors ${
                       errors.age
                         ? "border-red-500"
-                        : "border-gray-300 dark:border-white/10"
+                        : "border-gray-300 dark:border-gray-600 focus-within:border-green-500 dark:focus-within:border-green-500"
                     }`}
                   >
-                    <Calendar size={18} className="text-gray-400 mr-2" />
+                    <Calendar size={18} className="text-gray-400 dark:text-gray-400 mr-2 shrink-0" />
                     <input
                       type="number"
                       name="age"
                       value={formData.age}
                       onChange={handleChange}
                       placeholder="Enter your age"
-                      className="w-full bg-transparent outline-none py-3 text-black dark:text-white placeholder-gray-500"
+                      className="w-full bg-transparent outline-none py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400"
                     />
                   </div>
                   {errors.age && (
@@ -405,23 +405,23 @@ const Profile = () => {
                 </div>
 
                 <div>
-                  <label className="block mb-2 text-sm font-medium text-black dark:text-white">
+                  <label className="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
                     Gender
                   </label>
                   <select
                     name="gender"
                     value={formData.gender}
                     onChange={handleChange}
-                    className={`w-full bg-white dark:bg-white/5 border rounded-xl px-4 py-3 outline-none text-black dark:text-white ${
+                    className={`w-full bg-white dark:bg-[#263238] border rounded-xl px-4 py-3 outline-none text-gray-900 dark:text-white transition-colors ${
                       errors.gender
                         ? "border-red-500"
-                        : "border-gray-300 dark:border-white/10"
+                        : "border-gray-300 dark:border-gray-600 focus:border-green-500 dark:focus:border-green-500"
                     }`}
                   >
-                    <option value="">Select gender</option>
-                    <option value="Male">Male</option>
-                    <option value="Female">Female</option>
-                    <option value="Other">Other</option>
+                    <option value="" className="bg-white dark:bg-[#263238] text-gray-900 dark:text-white">Select gender</option>
+                    <option value="Male" className="bg-white dark:bg-[#263238] text-gray-900 dark:text-white">Male</option>
+                    <option value="Female" className="bg-white dark:bg-[#263238] text-gray-900 dark:text-white">Female</option>
+                    <option value="Other" className="bg-white dark:bg-[#263238] text-gray-900 dark:text-white">Other</option>
                   </select>
                   {errors.gender && (
                     <p className="text-red-500 text-sm mt-1">{errors.gender}</p>
@@ -429,24 +429,24 @@ const Profile = () => {
                 </div>
 
                 <div>
-                  <label className="block mb-2 text-sm font-medium text-black dark:text-white">
+                  <label className="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
                     Email
                   </label>
                   <div
-                    className={`flex items-center bg-white dark:bg-white/5 border rounded-xl px-3 ${
+                    className={`flex items-center bg-white dark:bg-[#263238] border rounded-xl px-3 transition-colors ${
                       errors.email
                         ? "border-red-500"
-                        : "border-gray-300 dark:border-white/10"
+                        : "border-gray-300 dark:border-gray-600 focus-within:border-green-500 dark:focus-within:border-green-500"
                     }`}
                   >
-                    <Mail size={18} className="text-gray-400 mr-2" />
+                    <Mail size={18} className="text-gray-400 dark:text-gray-400 mr-2 shrink-0" />
                     <input
                       type="email"
                       name="email"
                       value={formData.email}
                       onChange={handleChange}
                       placeholder="Enter your email"
-                      className="w-full bg-transparent outline-none py-3 text-black dark:text-white placeholder-gray-500"
+                      className="w-full bg-transparent outline-none py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400"
                     />
                   </div>
                   {errors.email && (
@@ -455,24 +455,24 @@ const Profile = () => {
                 </div>
 
                 <div>
-                  <label className="block mb-2 text-sm font-medium text-black dark:text-white">
+                  <label className="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
                     Phone
                   </label>
                   <div
-                    className={`flex items-center bg-white dark:bg-white/5 border rounded-xl px-3 ${
+                    className={`flex items-center bg-white dark:bg-[#263238] border rounded-xl px-3 transition-colors ${
                       errors.phone
                         ? "border-red-500"
-                        : "border-gray-300 dark:border-white/10"
+                        : "border-gray-300 dark:border-gray-600 focus-within:border-green-500 dark:focus-within:border-green-500"
                     }`}
                   >
-                    <Phone size={18} className="text-gray-400 mr-2" />
+                    <Phone size={18} className="text-gray-400 dark:text-gray-400 mr-2 shrink-0" />
                     <input
                       type="text"
                       name="phone"
                       value={formData.phone}
                       onChange={handleChange}
                       placeholder="Enter your phone number"
-                      className="w-full bg-transparent outline-none py-3 text-black dark:text-white placeholder-gray-500"
+                      className="w-full bg-transparent outline-none py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400"
                     />
                   </div>
                   {errors.phone && (
@@ -481,24 +481,24 @@ const Profile = () => {
                 </div>
 
                 <div>
-                  <label className="block mb-2 text-sm font-medium text-black dark:text-white">
+                  <label className="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
                     Address
                   </label>
                   <div
-                    className={`flex items-center bg-white dark:bg-white/5 border rounded-xl px-3 ${
+                    className={`flex items-center bg-white dark:bg-[#263238] border rounded-xl px-3 transition-colors ${
                       errors.address
                         ? "border-red-500"
-                        : "border-gray-300 dark:border-white/10"
+                        : "border-gray-300 dark:border-gray-600 focus-within:border-green-500 dark:focus-within:border-green-500"
                     }`}
                   >
-                    <MapPin size={18} className="text-gray-400 mr-2" />
+                    <MapPin size={18} className="text-gray-400 dark:text-gray-400 mr-2 shrink-0" />
                     <input
                       type="text"
                       name="address"
                       value={formData.address}
                       onChange={handleChange}
                       placeholder="Enter your address"
-                      className="w-full bg-transparent outline-none py-3 text-black dark:text-white placeholder-gray-500"
+                      className="w-full bg-transparent outline-none py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400"
                     />
                   </div>
                   {errors.address && (
@@ -508,7 +508,7 @@ const Profile = () => {
               </div>
 
               <div>
-                <label className="block mb-2 text-sm font-medium text-black dark:text-white">
+                <label className="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
                   Bio
                 </label>
                 <textarea
@@ -517,10 +517,10 @@ const Profile = () => {
                   onChange={handleChange}
                   rows="5"
                   placeholder="Write something about yourself..."
-                  className={`w-full bg-white dark:bg-white/5 border rounded-xl px-4 py-3 outline-none text-black dark:text-white placeholder-gray-500 ${
+                  className={`w-full bg-white dark:bg-[#263238] border rounded-xl px-4 py-3 outline-none text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 transition-colors ${
                     errors.bio
                       ? "border-red-500"
-                      : "border-gray-300 dark:border-white/10"
+                      : "border-gray-300 dark:border-gray-600 focus:border-green-500 dark:focus:border-green-500"
                   }`}
                 />
                 {errors.bio && (

--- a/next_webapp/tailwind.config.ts
+++ b/next_webapp/tailwind.config.ts
@@ -14,7 +14,6 @@ const config: Config = {
         primary: "var(--color-primary)",
         dark:    "var(--color-dark)",
         light:   "var(--color-light)",
-        white:   "var(--color-white)",
       },
       fontFamily: {
         sans: ["Poppins", "sans-serif"],


### PR DESCRIPTION
## Description
Fixes an issue on the User Profile page (`/profile`) where form inputs rendered with solid white backgrounds and white text in dark mode, making input text and saved values invisible/unreadable.

## Problem & Root Cause
1. **Broken Tailwind Opacity Utilities**: In `tailwind.config.ts`, `white` was mapped to `var(--color-white)` (a hex color `#ffffff`). In Tailwind CSS v3, applying alpha opacity modifiers (such as `dark:bg-white/5` or `dark:border-white/10`) to CSS variable hex strings results in invalid CSS properties (`rgb(#ffffff / 0.05)`), causing browsers to discard the rule and fall back to solid white (`bg-white`).
2. **Form Theming & Contrast**: Inputs in the profile form lacked explicit dark background tokens, causing white text (`dark:text-white`) to display over white backgrounds. In addition, the Gender dropdown options were unstyled in dark mode.

## Changes Made
- **`tailwind.config.ts`**:
  - Removed `white: "var(--color-white)"` from `extend.colors`, allowing Tailwind to use standard `#ffffff` with its native alpha-channel opacity modifiers across all components.
- **`src/app/[locale]/profile/page.jsx`**:
  - **Input Backgrounds**: Set input wrappers, textarea, and select dropdown to `bg-white dark:bg-[#263238]` to match the dark theme palette.
  - **Text & Placeholder Colors**: Updated text styling to `text-gray-900 dark:text-white` and placeholders to `placeholder-gray-400 dark:placeholder-gray-400` for clear contrast in both light and dark modes.
  - **Borders & Focus States**: Updated to `border-gray-300 dark:border-gray-600` with responsive focus states (`focus-within:border-green-500` / `focus:border-green-500`).
  - **Dropdown Options**: Added explicit dark classes on `<option>` elements (`bg-white dark:bg-[#263238] text-gray-900 dark:text-white`) so choices are clearly legible when opening the select menu in dark mode.
  - **Avatar & Labels**: Updated the profile photo container to `bg-white dark:bg-[#263238] border-gray-200 dark:border-gray-700` and aligned labels with `text-gray-700 dark:text-gray-200`.

## Testing

<img width="878" height="500" alt="image" src="https://github.com/user-attachments/assets/3081113a-8913-4a98-9efd-b8a41165302e" />
