### PR TITLE
WD: fix auth regression and activity logging

### DIFF
--- a/next_webapp/src/app/api/admin/activity-history/route.ts
+++ b/next_webapp/src/app/api/admin/activity-history/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/library/supabaseClient';
+import dbConnect from "@/lib/dbConnect";
+import Log from "@/models/mongoose/Log";
+import User from "@/models/mongoose/User";
 import { getAuthUser } from '@/app/api/library/auth';
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 function formatActivity(method: string | null, url: string | null): string {
   if (!method || !url) return 'Unknown action';
@@ -47,130 +53,173 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false, message: 'Forbidden' }, { status: 403 });
   }
 
-  const url   = new URL(request.url);
-  const sp    = url.searchParams;
+  try {
+    await dbConnect();
+    const url   = new URL(request.url);
+    const sp    = url.searchParams;
 
-  const format     = sp.get('format') ?? 'json';           // 'json' | 'csv'
-  const includeGet = sp.get('includeGet') === 'true';       // default: write-ops only
-  const search     = sp.get('search')?.trim() ?? '';
+    const format     = sp.get('format') ?? 'json';           // 'json' | 'csv'
+    const includeGet = sp.get('includeGet') === 'true';       // default: write-ops only
+    const search     = sp.get('search')?.trim() ?? '';
 
-  // Sort
-  const rawSortBy    = sp.get('sortBy') ?? 'timestamp';
-  const rawSortOrder = sp.get('sortOrder') ?? 'desc';
-  const sortBy       = ALLOWED_SORT_COLUMNS.has(rawSortBy) ? rawSortBy : 'timestamp';
-  const ascending    = rawSortOrder.toLowerCase() === 'asc';
+    // Sort
+    const rawSortBy    = sp.get('sortBy') ?? 'timestamp';
+    const rawSortOrder = sp.get('sortOrder') ?? 'desc';
+    const sortBy       = ALLOWED_SORT_COLUMNS.has(rawSortBy) ? rawSortBy : 'timestamp';
+    const ascending    = rawSortOrder.toLowerCase() === 'asc';
 
-  // Pagination (ignored for CSV export — returns all rows)
-  const page     = Math.max(1, parseInt(sp.get('page')     || '1'));
-  const pageSize = Math.min(50, parseInt(sp.get('pageSize') || '20'));
-  const offset   = (page - 1) * pageSize;
+    // Pagination (ignored for CSV export — returns all rows)
+    const page     = Math.max(1, parseInt(sp.get('page')     || '1'));
+    const pageSize = Math.min(50, parseInt(sp.get('pageSize') || '20'));
+    const offset   = (page - 1) * pageSize;
 
-  // Resolve search term → matching user_ids
-  let filterUserIds: number[] | null = null;
-  if (search) {
-    const [{ data: detailsMatch }, { data: emailMatch }] = await Promise.all([
-      supabase
-        .from('user_details')
-        .select('user_id')
-        .or(`first_name.ilike.%${search}%,last_name.ilike.%${search}%`),
-      supabase
-        .from('user')
-        .select('id')
-        .ilike('email', `%${search}%`),
-    ]);
+    // Resolve search term → matching user_ids
+    let filterUserIds: string[] | null = null;
+    if (search) {
+      const escapedSearch = escapeRegex(search);
 
-    const ids = new Set<number>();
-    detailsMatch?.forEach((d) => ids.add(d.user_id));
-    emailMatch?.forEach((u)   => ids.add(u.id));
-    filterUserIds = Array.from(ids);
+      const matchingUsers = await User.find({
+        $or: [
+          { email: { $regex: escapedSearch, $options: "i" } },
+          { "profile.first_name": { $regex: escapedSearch, $options: "i" } },
+          { "profile.last_name": { $regex: escapedSearch, $options: "i" } },
+        ],
+      })
+        .select("_id")
+        .lean();
 
-    if (filterUserIds.length === 0) {
-      const emptyPagination = { page, pageSize, total: 0, totalPages: 0 };
-      if (format === 'csv') return new NextResponse('id,activity,performedBy,performedAt\n', {
-        headers: { 'Content-Type': 'text/csv', 'Content-Disposition': 'attachment; filename="activity-history.csv"' },
-      });
-      return NextResponse.json({ success: true, data: [], pagination: emptyPagination });
+      filterUserIds = matchingUsers.map((u) => u._id.toString());
+
+      if (filterUserIds.length === 0) {
+        const emptyPagination = {
+          page,
+          pageSize,
+          total: 0,
+          totalPages: 0,
+        };
+
+        if (format === "csv") {
+          return new NextResponse(
+            "id,activity,performedBy,performedAt\n",
+            {
+              headers: {
+                "Content-Type": "text/csv",
+                "Content-Disposition":
+                  'attachment; filename="activity-history.csv"',
+              },
+            }
+          );
+        }
+
+        return NextResponse.json({
+          success: true,
+          data: [],
+          pagination: emptyPagination,
+        });
+      }
     }
-  }
 
-  // Build base query
-  let query = supabase
-    .from('logs')
-    .select('id, method, url, user_id, timestamp', { count: 'exact' })
-    .eq('source', 'middleware')
-    .not('user_id', 'is', null)
-    .order(sortBy, { ascending });
+    // Build base query
+    const logFilter: Record<string, unknown> = {
+      source: "middleware",
+      user_id: { $ne: null },
+    };
 
-  if (!includeGet) {
-    query = query.in('method', ['POST', 'PUT', 'PATCH', 'DELETE']);
-  }
+    if (!includeGet) {
+      logFilter.method = {
+        $in: ["POST", "PUT", "PATCH", "DELETE"],
+      };
+    }
 
-  if (filterUserIds !== null) {
-    query = query.in('user_id', filterUserIds);
-  }
+    if (filterUserIds !== null) {
+      logFilter.user_id = {
+        $in: filterUserIds,
+      };
+    }
 
-  // For CSV, fetch all records; for JSON, paginate
-  if (format !== 'csv') {
-    query = query.range(offset, offset + pageSize - 1);
-  }
+    const sortDirection = ascending ? 1 : -1;
 
-  const { data: logs, error, count } = await query;
+    let logsQuery = Log.find(logFilter)
+      .sort({ [sortBy]: sortDirection });
 
-  if (error) {
-    return NextResponse.json({ success: false, message: 'Failed to fetch activity' }, { status: 500 });
-  }
+    if (format !== "csv") {
+      logsQuery = logsQuery
+        .skip(offset)
+        .limit(pageSize);
+    }
 
-  // Resolve user display names
-  const userIds = [...new Set((logs ?? []).map((l) => l.user_id).filter(Boolean))] as number[];
-  const userNameMap: Record<number, string> = {};
-
-  if (userIds.length > 0) {
-    const [{ data: details }, { data: users }] = await Promise.all([
-      supabase.from('user_details').select('user_id, first_name, last_name').in('user_id', userIds),
-      supabase.from('user').select('id, email').in('id', userIds),
+    const [logs, total] = await Promise.all([
+      logsQuery.lean(),
+      Log.countDocuments(logFilter),
     ]);
 
-    const emailMap: Record<number, string> = {};
-    users?.forEach((u) => { emailMap[u.id] = u.email; });
+    // Resolve user display names
+    const userIds = [
+      ...new Set(
+        logs
+          .map((l) => l.user_id?.toString())
+          .filter((id): id is string => Boolean(id))
+      ),
+    ];
 
-    details?.forEach((d) => {
-      const name = `${d.first_name ?? ''} ${d.last_name ?? ''}`.trim();
-      userNameMap[d.user_id] = name || emailMap[d.user_id] || `User #${d.user_id}`;
+    const userNameMap: Record<string, string> = {};
+
+    if (userIds.length > 0) {
+        const users = await User.find({
+          _id: { $in: userIds },
+        })
+          .select("_id email profile.first_name profile.last_name")
+          .lean();
+
+      users.forEach((user) => {
+        const id = user._id.toString();
+        const name =
+          `${user.profile?.first_name ?? ""} ${user.profile?.last_name ?? ""}`.trim();userNameMap[id] =name ||user.email || `User #${id}`;
+      });
+    }
+
+    const mapped = logs.map((log) => {
+      const userId = log.user_id?.toString();
+
+      return {
+        id: log._id.toString(),
+        activity: formatActivity(log.method, log.url),
+        performedBy: userId
+          ? userNameMap[userId] ?? `User #${userId}`
+          : "System",
+        performedAt: log.timestamp,
+      };
     });
 
-    userIds.forEach((id) => {
-      if (!userNameMap[id]) userNameMap[id] = emailMap[id] || `User #${id}`;
+    // ── CSV export ────────────────────────────────────────────────────────────
+    if (format === 'csv') {
+      const escape = (v: string) => `"${String(v ?? '').replace(/"/g, '""')}"`;
+      const rows = mapped.map((r) =>
+        [r.id, escape(r.activity), escape(r.performedBy), r.performedAt].join(',')
+      );
+      const csv = ['id,activity,performedBy,performedAt', ...rows].join('\n');
+
+      return new NextResponse(csv, {
+        headers: {
+          'Content-Type': 'text/csv',
+          'Content-Disposition': 'attachment; filename="activity-history.csv"',
+        },
+      });
+    }
+
+    // ── JSON response ─────────────────────────────────────────────────────────
+    return NextResponse.json({
+      success: true,
+      data: mapped,
+      pagination: { page, pageSize, total, totalPages: Math.ceil(total / pageSize) },
     });
   }
+  catch (error) {
+      console.error("[GET /api/activity] error:", error);
 
-  const mapped = (logs ?? []).map((log) => ({
-    id: log.id,
-    activity:    formatActivity(log.method, log.url),
-    performedBy: log.user_id ? (userNameMap[log.user_id] ?? `User #${log.user_id}`) : 'System',
-    performedAt: log.timestamp,
-  }));
-
-  // ── CSV export ────────────────────────────────────────────────────────────
-  if (format === 'csv') {
-    const escape = (v: string) => `"${String(v ?? '').replace(/"/g, '""')}"`;
-    const rows = mapped.map((r) =>
-      [r.id, escape(r.activity), escape(r.performedBy), r.performedAt].join(',')
-    );
-    const csv = ['id,activity,performedBy,performedAt', ...rows].join('\n');
-
-    return new NextResponse(csv, {
-      headers: {
-        'Content-Type': 'text/csv',
-        'Content-Disposition': 'attachment; filename="activity-history.csv"',
-      },
-    });
-  }
-
-  // ── JSON response ─────────────────────────────────────────────────────────
-  const total = count ?? 0;
-  return NextResponse.json({
-    success: true,
-    data: mapped,
-    pagination: { page, pageSize, total, totalPages: Math.ceil(total / pageSize) },
-  });
+      return NextResponse.json(
+        { success: false, message: "Failed to fetch activity" },
+        { status: 500 }
+      );
+    }
 }

--- a/next_webapp/src/app/api/admin/activity-history/route.ts
+++ b/next_webapp/src/app/api/admin/activity-history/route.ts
@@ -174,7 +174,8 @@ export async function GET(request: NextRequest) {
       users.forEach((user) => {
         const id = user._id.toString();
         const name =
-          `${user.profile?.first_name ?? ""} ${user.profile?.last_name ?? ""}`.trim();userNameMap[id] =name ||user.email || `User #${id}`;
+          `${user.profile?.first_name ?? ""} ${user.profile?.last_name ?? ""}`.trim();
+          userNameMap[id] =name ||user.email || `User #${id}`;
       });
     }
 

--- a/next_webapp/src/app/api/blogs/[id]/route.ts
+++ b/next_webapp/src/app/api/blogs/[id]/route.ts
@@ -1,21 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/library/supabaseClient";
+import { getAuthUser } from "@/app/api/library/auth";
 import logger from "@/utils/logger";
-
-// ─── Auth helpers ─────────────────────────────────────────────────────────────
-
-function getUserId(request: NextRequest): number | null {
-  const raw = request.headers.get("x-user-id");
-  if (!raw) return null;
-  const id = Number(raw);
-  return Number.isFinite(id) ? id : null;
-}
-
-function isAdmin(request: NextRequest): boolean {
-  const role = request.headers.get("x-user-role");
-  const roleId = request.headers.get("x-user-role-id");
-  return role?.toLowerCase() === "admin" || roleId === "1";
-}
 
 // ─── Response helpers ─────────────────────────────────────────────────────────
 
@@ -118,9 +104,9 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const userId = getUserId(request);
-  if (!userId) return unauthorized();
-  if (!isAdmin(request)) return forbidden();
+  const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
+  if (!isAuthenticated || !userId) return unauthorized();
+  if (!isAdmin) return forbidden();
 
   const { id } = await params;
   const blogId = Number(id);
@@ -215,9 +201,9 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const userId = getUserId(request);
-  if (!userId) return unauthorized();
-  if (!isAdmin(request)) return forbidden();
+  const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
+  if (!isAuthenticated || !userId) return unauthorized();
+  if (!isAdmin) return forbidden();
 
   const { id } = await params;
   const blogId = Number(id);

--- a/next_webapp/src/app/api/blogs/route.ts
+++ b/next_webapp/src/app/api/blogs/route.ts
@@ -1,20 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/library/supabaseClient";
-
-// ─── Auth helpers ────────────────────────────────────────────────────────────
-
-function getUserId(request: NextRequest): number | null {
-  const raw = request.headers.get("x-user-id");
-  if (!raw) return null;
-  const id = Number(raw);
-  return Number.isFinite(id) ? id : null;
-}
-
-function isAdmin(request: NextRequest): boolean {
-  const role = request.headers.get("x-user-role");
-  const roleId = request.headers.get("x-user-role-id");
-  return role?.toLowerCase() === "admin" || roleId === "1";
-}
+import { getAuthUser } from "@/app/api/library/auth";
 
 // ─── Response helpers ─────────────────────────────────────────────────────────
 
@@ -107,9 +93,9 @@ function validateImage(file: File): string | null {
 // ─── POST — create blog ───────────────────────────────────────────────────────
 
 export async function POST(request: NextRequest) {
-  const userId = getUserId(request);
-  if (!userId) return unauthorized();
-  if (!isAdmin(request)) return forbidden();
+  const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
+  if (!isAuthenticated || !userId) return unauthorized();
+  if (!isAdmin) return forbidden();
 
   try {
     const formData = await request.formData();

--- a/next_webapp/src/app/api/categories/[id]/route.ts
+++ b/next_webapp/src/app/api/categories/[id]/route.ts
@@ -56,25 +56,26 @@ export async function PUT(
     request: Request,
     { params }: { params: Promise<{ id: string }> }
 ) {
+    const { userId, isAdmin } = getAuthUser(request as any);
+
     try {
         // ==============================
         // 1. Auth check
         // ==============================
-        const { userId, isAdmin } = getAuthUser(request as any);
 
         if (!userId) {
-            return errorResponse("User not authenticated", 401, "UNAUTHORIZED");
+            return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request, userId);
         }
 
         if (!isAdmin) {
-            return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN");
+            return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request, userId);
         }
 
         const { id } = await params;
         const categoryId = Number(id);
 
         if (!categoryId) {
-            return errorResponse("Invalid category ID", 400, "INVALID_ID");
+            return errorResponse("Invalid category ID", 400, "INVALID_ID", request, userId);
         }
 
         // ==============================
@@ -89,7 +90,7 @@ export async function PUT(
         const validationError = validateUpdateCategory(cleanData);
 
         if (validationError) {
-            return errorResponse(validationError, 400, "VALIDATION_ERROR");
+            return errorResponse(validationError, 400, "VALIDATION_ERROR", request, userId);
         }
 
         // ==============================
@@ -102,7 +103,7 @@ export async function PUT(
             .single();
 
         if (fetchError || !existing) {
-            return errorResponse("Category not found", 404, "NOT_FOUND");
+            return errorResponse("Category not found", 404, "NOT_FOUND", request, userId);
         }
 
         // ==============================
@@ -122,7 +123,9 @@ export async function PUT(
                 return errorResponse(
                     "Failed to validate category",
                     500,
-                    "DB_CHECK_ERROR"
+                    "DB_CHECK_ERROR",
+                    request,
+                    userId
                 );
             }
 
@@ -130,7 +133,9 @@ export async function PUT(
                 return errorResponse(
                     "Category with this name already exists",
                     400,
-                    "DUPLICATE_CATEGORY"
+                    "DUPLICATE_CATEGORY",
+                    request,
+                    userId
                 );
             }
         }
@@ -150,7 +155,7 @@ export async function PUT(
 
         if (error) {
             console.error("Update error:", error);
-            return errorResponse("Failed to update category", 500, "DB_UPDATE_ERROR");
+            return errorResponse("Failed to update category", 500, "DB_UPDATE_ERROR", request, userId);
         }
 
         // ==============================
@@ -179,7 +184,9 @@ export async function PUT(
         return errorResponse(
             "Internal Server Error",
             500,
-            "INTERNAL_ERROR"
+            "INTERNAL_ERROR",
+            request,
+            userId
         );
     }
 }
@@ -193,23 +200,24 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const { userId, isAdmin } = getAuthUser(request);
+
   try {
     // 1. Auth check
-    const { userId, isAdmin } = getAuthUser(request);
 
     if (!userId) {
-      return errorResponse("User not authenticated", 401, "UNAUTHORIZED");
+      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request, userId);
     }
 
     if (!isAdmin) {
-      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN");
+      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request, userId);
     }
 
     const { id } = await params;
     const categoryId = Number(id);
 
     if (!categoryId || Number.isNaN(categoryId)) {
-      return errorResponse("Invalid category ID", 400, "INVALID_ID");
+      return errorResponse("Invalid category ID", 400, "INVALID_ID", request, userId);
     }
 
     // 2. Check category exists
@@ -220,7 +228,7 @@ export async function DELETE(
       .single();
 
     if (categoryError || !existingCategory) {
-      return errorResponse("Category not found", 404, "CATEGORY_NOT_FOUND");
+      return errorResponse("Category not found", 404, "CATEGORY_NOT_FOUND", request, userId);
     }
 
     // 3. Count how many use cases are using this category
@@ -234,7 +242,9 @@ export async function DELETE(
       return errorResponse(
         "Failed to validate category usage",
         500,
-        "USAGE_CHECK_ERROR"
+        "USAGE_CHECK_ERROR",
+        request,
+        userId
       );
     }
 
@@ -265,7 +275,9 @@ export async function DELETE(
       return errorResponse(
         "Failed to delete category",
         500,
-        "DELETE_ERROR"
+        "DELETE_ERROR",
+        request,
+        userId
       );
     }
 
@@ -283,6 +295,6 @@ export async function DELETE(
     );
   } catch (error) {
     console.error("Delete Category Error:", error);
-    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR");
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request, userId);
   }
 }

--- a/next_webapp/src/app/api/categories/route.ts
+++ b/next_webapp/src/app/api/categories/route.ts
@@ -16,18 +16,19 @@ import logger from "@/utils/logger";
 // ==============================
 
 export async function POST(request: NextRequest) {
+    const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
+
     try {
         // ==============================
         // 1. Check Admin Authorization
         // ==============================
-        const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
 
         if (!isAuthenticated) {
-            return errorResponse("User not authenticated", 401, "UNAUTHORIZED");
+            return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request, userId);
         }
 
         if (!isAdmin) {
-            return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN");
+            return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request, userId);
         }
 
 
@@ -43,7 +44,7 @@ export async function POST(request: NextRequest) {
         const validationError = validateCreateCategory(cleanData);
 
         if (validationError) {
-            return errorResponse(validationError, 400, "VALIDATION_ERROR");
+            return errorResponse(validationError, 400, "VALIDATION_ERROR", request, userId);
         }
 
         const { category_name, description, cover_img } = cleanData;
@@ -63,7 +64,9 @@ export async function POST(request: NextRequest) {
             return errorResponse(
                 "Failed to validate category",
                 500,
-                "DB_CHECK_ERROR"
+                "DB_CHECK_ERROR",
+                request,
+                userId
             );
         }
 
@@ -71,7 +74,9 @@ export async function POST(request: NextRequest) {
             return errorResponse(
                 "Category already exists",
                 400,
-                "DUPLICATE_CATEGORY"
+                "DUPLICATE_CATEGORY",
+                request,
+                userId
             );
         }
 
@@ -107,7 +112,9 @@ export async function POST(request: NextRequest) {
             return errorResponse(
                 "Failed to create category",
                 500,
-                "DB_INSERT_ERROR"
+                "DB_INSERT_ERROR",
+                request,
+                userId
             );
         }
 
@@ -131,7 +138,9 @@ export async function POST(request: NextRequest) {
         return errorResponse(
             "Internal Server Error",
             500,
-            "INTERNAL_ERROR"
+            "INTERNAL_ERROR",
+            request,
+            userId
         );
     }
 }

--- a/next_webapp/src/app/api/contributors/[id]/route.ts
+++ b/next_webapp/src/app/api/contributors/[id]/route.ts
@@ -42,26 +42,25 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
   try {
-    const { isAuthenticated, isAdmin } = getAuthUser(request);
     if (!isAuthenticated) {
-      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request);
+      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request, userId);
     }
     if (!isAdmin) {
-      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request);
+      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request, userId);
     }
 
     const { id } = await params;
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      return errorResponse("Invalid contributor ID", 400, "INVALID_ID", request);
+      return errorResponse("Invalid contributor ID", 400, "INVALID_ID", request, userId);
     }
-
     let body;
     try {
       body = await request.json();
     } catch (error) {
       if (error instanceof SyntaxError) {
-        return errorResponse("Invalid JSON in request body.", 400, "INVALID_JSON", request);
+        return errorResponse("Invalid JSON in request body.", 400, "INVALID_JSON", request, userId);
       }
       throw error;
     }
@@ -70,7 +69,7 @@ export async function PUT(
 
     const existing = await Contributor.findById(id);
     if (!existing) {
-      return errorResponse("Contributor not found", 404, "NOT_FOUND", request);
+      return errorResponse("Contributor not found", 404, "NOT_FOUND", request, userId);
     }
 
     const isStudent = body.contributor_type === "student";
@@ -96,10 +95,10 @@ export async function PUT(
     return NextResponse.json({ success: true, data: toContributorDTO(existing.toObject()) });
   } catch (error) {
     if (error instanceof Error && error.name === "ValidationError") {
-      return errorResponse(error.message, 400, "VALIDATION_ERROR", request);
+      return errorResponse(error.message, 400, "VALIDATION_ERROR", request, userId);
     }
     console.error("Update Contributor Error:", error);
-    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request);
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request, userId);
   }
 }
 
@@ -111,33 +110,34 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const {userId, isAuthenticated, isAdmin } = getAuthUser(request);
   try {
-    const { isAuthenticated, isAdmin } = getAuthUser(request);
     if (!isAuthenticated) {
-      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request);
+      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request, userId);
     }
     if (!isAdmin) {
-      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request);
+      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request, userId);
     }
 
     const { id } = await params;
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      return errorResponse("Invalid contributor ID", 400, "INVALID_ID", request);
+      return errorResponse("Invalid contributor ID", 400, "INVALID_ID", request, userId);
     }
 
     await dbConnect();
 
     const deleted = await Contributor.findByIdAndDelete(id);
     if (!deleted) {
-      return errorResponse("Contributor not found", 404, "NOT_FOUND", request);
+      return errorResponse("Contributor not found", 404, "NOT_FOUND", request, userId);
     }
 
     return NextResponse.json({
       success: true,
       message: "Contributor deleted successfully",
     });
-  } catch (error) {
+  } 
+  catch (error) {
     console.error("Delete Contributor Error:", error);
-    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request);
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request, userId);
   }
 }

--- a/next_webapp/src/app/api/contributors/route.ts
+++ b/next_webapp/src/app/api/contributors/route.ts
@@ -32,13 +32,13 @@ export async function GET(request: NextRequest) {
 // Create a contributor (ADMIN ONLY)
 // ==============================
 export async function POST(request: NextRequest) {
+  const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
   try {
-    const { isAuthenticated, isAdmin } = getAuthUser(request);
     if (!isAuthenticated) {
-      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request);
+      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request, userId);
     }
     if (!isAdmin) {
-      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request);
+      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request, userId);
     }
 
     let body;
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
       body = await request.json();
     } catch (error) {
       if (error instanceof SyntaxError) {
-        return errorResponse("Invalid JSON in request body.", 400, "INVALID_JSON", request);
+        return errorResponse("Invalid JSON in request body.", 400, "INVALID_JSON", request, userId);
       }
       throw error;
     }
@@ -71,9 +71,9 @@ export async function POST(request: NextRequest) {
     );
   } catch (error) {
     if (error instanceof Error && error.name === "ValidationError") {
-      return errorResponse(error.message, 400, "VALIDATION_ERROR", request);
+      return errorResponse(error.message, 400, "VALIDATION_ERROR", request, userId);
     }
     console.error("Create Contributor Error:", error);
-    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request);
+    return errorResponse("Internal Server Error", 500, "INTERNAL_ERROR", request, userId);
   }
 }

--- a/next_webapp/src/app/api/gallery/[id]/route.ts
+++ b/next_webapp/src/app/api/gallery/[id]/route.ts
@@ -1,26 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/library/supabaseClient";
 import { uploadImageToStorage } from "../../library/uploadImageToStorage";
+import { getAuthUser } from "@/app/api/library/auth";
+import { errorResponse } from "@/app/api/library/errorResponse";
 import logger from "@/utils/logger";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5 MB
 const MAX_TITLE_LENGTH = 200;
-
-// ── Auth helpers ───────────────────────────────────────────────────────────
-function getUserId(request: NextRequest): number | null {
-  const raw = request.headers.get("x-user-id");
-  if (!raw) return null;
-  const id = Number(raw);
-  return Number.isFinite(id) ? id : null;
-}
-
-function isAdmin(request: NextRequest): boolean {
-  const role = request.headers.get("x-user-role");
-  const roleId = request.headers.get("x-user-role-id");
-  return role?.toLowerCase() === "admin" || roleId === "1";
-}
 
 // ── Response helpers ───────────────────────────────────────────────────────
 function unauthorized() {
@@ -64,7 +52,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  if (!getUserId(request)) return unauthorized();
+  const { userId, isAuthenticated } = getAuthUser(request);
+
+  if (!isAuthenticated || !userId) return unauthorized();
 
   const galleryImageId = await parseId(params);
   if (!galleryImageId) return badRequest("Invalid gallery image id");
@@ -97,9 +87,15 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const userId = getUserId(request);
-  if (!userId) return unauthorized();
-  if (!isAdmin(request)) return forbidden();
+  const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
+
+  if (!isAuthenticated || !userId) {
+    return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request, userId);
+  }
+
+  if (!isAdmin) {
+    return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request, userId);
+  }
 
   const galleryImageId = await parseId(params);
   if (!galleryImageId) return badRequest("Invalid gallery image id");
@@ -172,7 +168,13 @@ export async function PUT(
 
     if (error) {
       console.error("[PUT /api/gallery/[id]] update error:", error);
-      return serverError("Failed to update gallery image");
+      return errorResponse(
+        "Failed to update gallery image",
+        500,
+        "DB_UPDATE_ERROR",
+        request,
+        userId
+      );
     }
 
     if (!galleryImage) return notFound();
@@ -186,7 +188,14 @@ export async function PUT(
     console.error("[PUT /api/gallery/[id]] unexpected error:", error);
     const message =
       error instanceof Error ? error.message : "Failed to update gallery image";
-    return serverError(message);
+
+    return errorResponse(
+      message,
+      500,
+      "INTERNAL_ERROR",
+      request,
+      userId
+    );
   }
 }
 
@@ -198,9 +207,15 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const userId = getUserId(request);
-  if (!userId) return unauthorized();
-  if (!isAdmin(request)) return forbidden();
+  const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
+
+  if (!isAuthenticated || !userId) {
+    return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request, userId);
+  }
+
+  if (!isAdmin) {
+    return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request, userId);
+  }
 
   const galleryImageId = await parseId(params);
   if (!galleryImageId) return badRequest("Invalid gallery image id");
@@ -221,7 +236,13 @@ export async function DELETE(
 
     if (error) {
       console.error("[DELETE /api/gallery/[id]] delete error:", error);
-      return serverError("Failed to delete gallery image");
+      return errorResponse(
+        "Failed to delete gallery image",
+        500,
+        "DELETE_ERROR",
+        request,
+        userId
+      );
     }
 
     // Best-effort: remove image file from storage and log the deletion
@@ -252,6 +273,12 @@ export async function DELETE(
     });
   } catch (error) {
     console.error("[DELETE /api/gallery/[id]] unexpected error:", error);
-    return serverError("Failed to delete gallery image");
+    return errorResponse(
+      "Failed to delete gallery image",
+      500,
+      "INTERNAL_ERROR",
+      request,
+      userId
+    );
   }
 }

--- a/next_webapp/src/app/api/gallery/route.ts
+++ b/next_webapp/src/app/api/gallery/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/library/supabaseClient";
 import { uploadImageToStorage } from "../library/uploadImageToStorage";
+import { getAuthUser } from "../library/auth";
+import { errorResponse } from "../library/errorResponse";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
@@ -8,20 +10,6 @@ const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5 MB
 const MAX_TITLE_LENGTH = 200;
 const DEFAULT_PAGE_SIZE = 12;
 const MAX_PAGE_SIZE = 100;
-
-// ── Auth helpers ───────────────────────────────────────────────────────────
-function getUserId(request: NextRequest): number | null {
-  const raw = request.headers.get("x-user-id");
-  if (!raw) return null;
-  const id = Number(raw);
-  return Number.isFinite(id) ? id : null;
-}
-
-function isAdmin(request: NextRequest): boolean {
-  const role = request.headers.get("x-user-role");
-  const roleId = request.headers.get("x-user-role-id");
-  return role?.toLowerCase() === "admin" || roleId === "1";
-}
 
 // ── Response helpers ───────────────────────────────────────────────────────
 function unauthorized() {
@@ -66,7 +54,9 @@ function validateImage(image: File | null): string | null {
 // Admin listing with pagination and optional title search.
 // Query params: page, pageSize, search
 export async function GET(request: NextRequest) {
-  if (!getUserId(request)) return unauthorized();
+  const { userId, isAuthenticated } = getAuthUser(request);
+
+  if (!isAuthenticated || !userId) return unauthorized();
 
   try {
     const url = new URL(request.url);
@@ -132,9 +122,15 @@ export async function GET(request: NextRequest) {
 // ── POST /api/gallery ──────────────────────────────────────────────────────
 // Admin only. Accepts multipart/form-data: title (string), image (File).
 export async function POST(request: NextRequest) {
-  const userId = getUserId(request);
-  if (!userId) return unauthorized();
-  if (!isAdmin(request)) return forbidden();
+  const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
+
+  if (!isAuthenticated || !userId) {
+    return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request, userId);
+  }
+
+  if (!isAdmin) {
+    return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request, userId);
+  }
 
   try {
     const formData = await request.formData();
@@ -171,7 +167,13 @@ export async function POST(request: NextRequest) {
 
     if (error) {
       console.error("[POST /api/gallery] insert error:", error);
-      return serverError("Failed to create gallery image");
+      return errorResponse(
+        "Failed to create gallery image",
+        500,
+        "DB_INSERT_ERROR",
+        request,
+        userId
+      );
     }
 
     return NextResponse.json(
@@ -186,6 +188,13 @@ export async function POST(request: NextRequest) {
     console.error("[POST /api/gallery] unexpected error:", error);
     const message =
       error instanceof Error ? error.message : "Failed to add gallery image";
-    return serverError(message);
+
+    return errorResponse(
+      message,
+      500,
+      "INTERNAL_ERROR",
+      request,
+      userId
+    );
   }
 }

--- a/next_webapp/src/app/api/library/errorResponse.ts
+++ b/next_webapp/src/app/api/library/errorResponse.ts
@@ -19,7 +19,7 @@ export function errorResponse(
     status: number,
     code?: string,
     request?: Request,
-    userId?: number
+    userId?: string | null
 ): NextResponse<ErrorBody> {
     // Log the error with additional context
     logger.error(`API Error Response: ${status} - ${message}${code ? ` (${code})` : ''}`, {

--- a/next_webapp/src/app/api/library/uploadImageToStorage.ts
+++ b/next_webapp/src/app/api/library/uploadImageToStorage.ts
@@ -15,7 +15,7 @@ export async function uploadImageToStorage({
   bucket: string;
   folder: string;
   prefix: string;
-  userId: number;
+  userId: string;
 }) {
   if (!file) {
     throw new Error("No image file provided");

--- a/next_webapp/src/app/api/logs/route.ts
+++ b/next_webapp/src/app/api/logs/route.ts
@@ -4,6 +4,7 @@ import dbConnect from '@/lib/dbConnect';
 import Log from '@/models/mongoose/Log';
 import User from '@/models/mongoose/User';
 import { getAuthUser } from '@/app/api/library/auth';
+import { errorResponse } from '@/app/api/library/errorResponse';
 import logger from '@/utils/logger';
 
 const ALLOWED_SORT = new Set([
@@ -269,20 +270,26 @@ export async function GET(request: NextRequest) {
 // DELETE /api/logs?olderThanDays=N
 // Deletes logs older than the requested number of days.
 export async function DELETE(request: NextRequest) {
-  try {
-    const authUser = getAuthUser(request);
+  const authUser = getAuthUser(request);
 
-    if (!authUser.isAuthenticated) {
-      return NextResponse.json(
-        { success: false, message: 'Unauthorized' },
-        { status: 401 },
+  try {
+    if (!authUser.isAuthenticated || !authUser.userId) {
+      return errorResponse(
+        'User not authenticated',
+        401,
+        'UNAUTHORIZED',
+        request,
+        authUser.userId,
       );
     }
 
     if (!authUser.isAdmin) {
-      return NextResponse.json(
-        { success: false, message: 'Forbidden - Admin only' },
-        { status: 403 },
+      return errorResponse(
+        'Forbidden - Admin only',
+        403,
+        'FORBIDDEN',
+        request,
+        authUser.userId,
       );
     }
 
@@ -293,12 +300,12 @@ export async function DELETE(request: NextRequest) {
     );
 
     if (!Number.isInteger(rawDays) || rawDays < 1) {
-      return NextResponse.json(
-        {
-          success: false,
-          message: 'olderThanDays must be a positive integer',
-        },
-        { status: 400 },
+      return errorResponse(
+        'olderThanDays must be a positive integer',
+        400,
+        'INVALID_OLDER_THAN_DAYS',
+        request,
+        authUser.userId,
       );
     }
 
@@ -333,12 +340,16 @@ export async function DELETE(request: NextRequest) {
       {
         source: 'api',
         url: '/api/logs',
+        user_id: authUser.userId,
       },
     );
 
-    return NextResponse.json(
-      { success: false, message: 'Internal Server Error' },
-      { status: 500 },
+    return errorResponse(
+      'Internal Server Error',
+      500,
+      'INTERNAL_ERROR',
+      request,
+      authUser.userId,
     );
   }
 }

--- a/next_webapp/src/app/api/profile/password/route.ts
+++ b/next_webapp/src/app/api/profile/password/route.ts
@@ -1,18 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
-import { supabase } from "@/library/supabaseClient";
+import dbConnect from "@/lib/dbConnect";
+import User from "@/models/mongoose/User";
+import { getAuthUser } from "@/app/api/library/auth";
 import { validatePasswordChangeInput } from "@/app/api/library/validators";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function getUserId(request: NextRequest): number | null {
-  const raw = request.headers.get("x-user-id");
-  if (!raw) return null;
-  const id = Number(raw);
-  return Number.isFinite(id) ? id : null;
-}
 
 function badRequest(message: string, errors?: { field: string; message: string }[]) {
   const response: any = { success: false, message };
@@ -38,8 +33,8 @@ function serverError() {
 // ---------------------------------------------------------------------------
 
 export async function PUT(request: NextRequest) {
-  const userId = getUserId(request);
-  if (!userId) return unauthorized();
+  const { userId, isAuthenticated } = getAuthUser(request);
+  if (!isAuthenticated || !userId) return unauthorized();
 
   // --- Parse body -----------------------------------------------------------
   let body: {
@@ -62,40 +57,31 @@ export async function PUT(request: NextRequest) {
   const { current_password, new_password, confirm_password } = body;
 
   // --- Fetch the stored bcrypt hash from the user table ---------------------
-  const { data: user, error: fetchError } = await supabase
-    .from("user")
-    .select("password")
-    .eq("id", userId)
-    .maybeSingle();
+  try {
+    await dbConnect();
 
-  if (fetchError) {
-    console.error("[PUT /api/profile/password] fetch error:", fetchError);
+    const user = await User.findById(userId).select("password");
+
+    // Return 401 (not 404) to avoid leaking whether a user ID exists
+    if (!user) return unauthorized();
+
+    // --- Verify the current password against the stored hash ------------------
+    const matches = await bcrypt.compare(current_password!, user.password);
+    if (!matches) return unauthorized("Current password is incorrect");
+
+    // --- Hash the new password and save it ------------------------------------
+    // 12 salt rounds = ~300ms on modern hardware, strong against brute force
+    const newHash = await bcrypt.hash(new_password!, 12);
+
+    user.password = newHash;
+    await user.save();
+
+    return NextResponse.json({
+      success: true,
+      message: "Password updated successfully",
+    });
+  } catch (error) {
+    console.error("[PUT /api/profile/password] error:", error);
     return serverError();
   }
-
-  // Return 401 (not 404) to avoid leaking whether a user ID exists
-  if (!user) return unauthorized();
-
-  // --- Verify the current password against the stored hash ------------------
-  const matches = await bcrypt.compare(current_password!, user.password);
-  if (!matches) return unauthorized("Current password is incorrect");
-
-  // --- Hash the new password and save it ------------------------------------
-  // 12 salt rounds = ~300ms on modern hardware, strong against brute force
-  const newHash = await bcrypt.hash(new_password!, 12);
-
-  const { error: updateError } = await supabase
-    .from("user")
-    .update({ password: newHash })
-    .eq("id", userId);
-
-  if (updateError) {
-    console.error("[PUT /api/profile/password] update error:", updateError);
-    return serverError();
-  }
-
-  return NextResponse.json({
-    success: true,
-    message: "Password updated successfully",
-  });
 }

--- a/next_webapp/src/app/api/profile/upload-image/route.ts
+++ b/next_webapp/src/app/api/profile/upload-image/route.ts
@@ -1,12 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/library/supabaseClient";
-
-function getUserId(request: NextRequest): number | null {
-  const raw = request.headers.get("x-user-id");
-  if (!raw) return null;
-  const id = Number(raw);
-  return Number.isFinite(id) ? id : null;
-}
+import { getAuthUser } from "@/app/api/library/auth";
 
 function unauthorized() {
   return NextResponse.json(
@@ -24,8 +18,8 @@ function badRequest(message: string) {
 }
 
 export async function POST(request: NextRequest) {
-  const userId = getUserId(request);
-  if (!userId) return unauthorized();
+  const { userId, isAuthenticated } = getAuthUser(request);
+  if (!isAuthenticated || !userId) return unauthorized();
 
   try {
     const formData = await request.formData();

--- a/next_webapp/src/app/api/upload/route.ts
+++ b/next_webapp/src/app/api/upload/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/library/supabaseClient";
+import { getAuthUser } from "../library/auth";
 
 // ==============================
 // POST /api/upload
@@ -9,10 +10,9 @@ import { supabase } from "@/library/supabaseClient";
 // ==============================
 
 export async function POST(request: NextRequest) {
-  const userIdRaw = request.headers.get("x-user-id");
-  const userId = userIdRaw ? Number(userIdRaw) : null;
+  const { userId, isAuthenticated } = getAuthUser(request);
 
-  if (!userId) {
+  if (!isAuthenticated || !userId) {
     return NextResponse.json(
       { success: false, message: "Unauthorised" },
       { status: 401 }

--- a/next_webapp/src/app/api/usecases/[id]/route.js
+++ b/next_webapp/src/app/api/usecases/[id]/route.js
@@ -83,20 +83,20 @@ export async function PUT(request, { params }) {
   // be cleaned up if the doc save fails afterward — same mint-then-cleanup
   // shape as POST, plus old-file retirement once the save succeeds (below).
   let newFileId = null;
+  const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
 
   try {
-    const { isAuthenticated, isAdmin } = getAuthUser(request);
     if (!isAuthenticated) {
-      return errorResponse('User not authenticated', 401, 'UNAUTHORIZED', request);
+      return errorResponse('User not authenticated', 401, 'UNAUTHORIZED', request, userId);
     }
     if (!isAdmin) {
-      return errorResponse('Forbidden - Admin only', 403, 'FORBIDDEN', request);
+      return errorResponse('Forbidden - Admin only', 403, 'FORBIDDEN', request, userId);
     }
 
     const { id } = await params;
 
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      return errorResponse('Invalid use case ID', 400, 'INVALID_ID', request);
+      return errorResponse('Invalid use case ID', 400, 'INVALID_ID', request, userId);
     }
 
     let body;
@@ -104,7 +104,7 @@ export async function PUT(request, { params }) {
       body = await request.json();
     } catch (error) {
       if (error instanceof SyntaxError) {
-        return errorResponse('Invalid JSON body', 400, 'INVALID_JSON', request);
+        return errorResponse('Invalid JSON body', 400, 'INVALID_JSON', request, userId);
       }
       throw error;
     }
@@ -116,6 +116,7 @@ export async function PUT(request, { params }) {
         400,
         'VALIDATION_ERROR',
         request,
+        userId,
       );
     }
 
@@ -144,7 +145,7 @@ export async function PUT(request, { params }) {
       contentProvided;
 
     if (!anyFieldProvided) {
-      return errorResponse('No fields provided to update', 400, 'NO_FIELDS', request);
+      return errorResponse('No fields provided to update', 400, 'NO_FIELDS', request, userId);
     }
 
     // Step 1: validate/size-check new content (case b only) — before
@@ -153,7 +154,7 @@ export async function PUT(request, { params }) {
     if (isReplacingContent) {
       const validation = validateNotebookContent(content);
       if (!validation.valid) {
-        return errorResponse(validation.message, validation.status, validation.code, request);
+        return errorResponse(validation.message, validation.status, validation.code, request, userId);
       }
       notebookBuffer = validation.notebookBuffer;
     }
@@ -162,7 +163,7 @@ export async function PUT(request, { params }) {
 
     const existing = await UseCase.findById(id);
     if (!existing) {
-      return errorResponse('Use case not found', 404, 'NOT_FOUND', request);
+      return errorResponse('Use case not found', 404, 'NOT_FOUND', request, userId);
     }
 
     // Capture the current file id before anything is mutated — this is
@@ -235,10 +236,10 @@ export async function PUT(request, { params }) {
     return NextResponse.json({ success: true, data: toUseCaseDTO(saved.toObject()) });
   } catch (error) {
     if (error instanceof Error && error.name === 'ValidationError') {
-      return errorResponse(error.message, 400, 'VALIDATION_ERROR', request);
+      return errorResponse(error.message, 400, 'VALIDATION_ERROR', request, userId);
     }
     console.error('[PUT /api/usecases/[id]] unexpected error:', error);
-    return errorResponse('Internal server error', 500, 'INTERNAL_ERROR', request);
+    return errorResponse('Internal server error', 500, 'INTERNAL_ERROR', request, userId);
   }
 }
 
@@ -247,26 +248,27 @@ export async function PUT(request, { params }) {
 // retires its GridFS notebook file (if any) — see the ordering rationale in
 // the comment below.
 export async function DELETE(request, { params }) {
+  const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
+
   try {
-    const { isAuthenticated, isAdmin } = getAuthUser(request);
     if (!isAuthenticated) {
-      return errorResponse('User not authenticated', 401, 'UNAUTHORIZED', request);
+      return errorResponse('User not authenticated', 401, 'UNAUTHORIZED', request, userId);
     }
     if (!isAdmin) {
-      return errorResponse('Forbidden - Admin only', 403, 'FORBIDDEN', request);
+      return errorResponse('Forbidden - Admin only', 403, 'FORBIDDEN', request, userId);
     }
 
     const { id } = await params;
 
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      return errorResponse('Invalid use case ID', 400, 'INVALID_ID', request);
+      return errorResponse('Invalid use case ID', 400, 'INVALID_ID', request, userId);
     }
 
     await dbConnect();
 
     const existing = await UseCase.findById(id);
     if (!existing) {
-      return errorResponse('Use case not found', 404, 'NOT_FOUND', request);
+      return errorResponse('Use case not found', 404, 'NOT_FOUND', request, userId);
     }
 
     // Capture before deleting the doc — nothing left to retire once it's gone.
@@ -298,6 +300,6 @@ export async function DELETE(request, { params }) {
     });
   } catch (error) {
     console.error('[DELETE /api/usecases/[id]] unexpected error:', error);
-    return errorResponse('Internal server error', 500, 'INTERNAL_ERROR', request);
+    return errorResponse('Internal server error', 500, 'INTERNAL_ERROR', request, userId);
   }
 }

--- a/next_webapp/src/app/api/usecases/route.js
+++ b/next_webapp/src/app/api/usecases/route.js
@@ -34,14 +34,14 @@ export async function POST(request) {
   // a missing file, but a harmless orphaned file (if cleanup itself fails)
   // is an acceptable worst case.
   let uploadedFileId = null;
+  const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
 
   try {
-    const { userId, isAuthenticated, isAdmin } = getAuthUser(request);
     if (!isAuthenticated) {
-      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request);
+      return errorResponse("User not authenticated", 401, "UNAUTHORIZED", request, userId);
     }
     if (!isAdmin) {
-      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request);
+      return errorResponse("Forbidden - Admin only", 403, "FORBIDDEN", request, userId);
     }
 
     let body;
@@ -49,7 +49,7 @@ export async function POST(request) {
       body = await request.json();
     } catch (error) {
       if (error instanceof SyntaxError) {
-        return errorResponse("Invalid JSON body", 400, "INVALID_JSON", request);
+        return errorResponse("Invalid JSON body", 400, "INVALID_JSON", request, userId);
       }
       throw error;
     }
@@ -60,7 +60,7 @@ export async function POST(request) {
     const { title, description, cover_img, category_id, tags, content } = body;
 
     if (typeof title !== "string" || title.trim().length === 0) {
-      return errorResponse("title is required", 400, "MISSING_FIELDS", request);
+      return errorResponse("title is required", 400, "MISSING_FIELDS", request, userId);
     }
 
     // content is optional — a use case can be created without a notebook,
@@ -71,7 +71,7 @@ export async function POST(request) {
     if (content !== undefined && content !== null && content !== "") {
       const validation = validateNotebookContent(content);
       if (!validation.valid) {
-        return errorResponse(validation.message, validation.status, validation.code, request);
+        return errorResponse(validation.message, validation.status, validation.code, request, userId);
       }
       contentType = validation.contentType;
       notebookBuffer = validation.notebookBuffer;
@@ -119,10 +119,10 @@ export async function POST(request) {
     );
   } catch (error) {
     if (error instanceof Error && error.name === "ValidationError") {
-      return errorResponse(error.message, 400, "VALIDATION_ERROR", request);
+      return errorResponse(error.message, 400, "VALIDATION_ERROR", request, userId);
     }
     console.error("[POST /api/usecases] unexpected error:", error);
-    return errorResponse("Internal server error", 500, "INTERNAL_ERROR", request);
+    return errorResponse("Internal server error", 500, "INTERNAL_ERROR", request, userId);
   }
 }
 


### PR DESCRIPTION
Task 1 – Auth regression

Replaced local Number(x-user-id) authentication with the shared getAuthUser() helper across the affected routes.
Updated admin checks to use the shared authentication logic.
Updated profile/password to read and write passwords using the MongoDB User model instead of the old Supabase user table.
Preserved existing Supabase storage/database behaviour outside the assigned migration scope.

Task 6 – Activity history / logging

Passed the authenticated userId into relevant admin mutation error/logging paths.
Updated errorResponse() to support MongoDB user IDs.
Migrated the Activity History read route to the MongoDB Log model.
Preserved the existing Activity History filtering behaviour.
Escaped user search input before using it in MongoDB regex queries.

Testing

Project builds successfully.
Verified MongoDB error logs can contain authenticated user IDs.
Verified Activity History correctly displays valid MongoDB middleware log records.
Existing Edge middleware only persists request logs to the console; automatic persistence of successful middleware activity to MongoDB is outside the scope of this change.