### PR TITLE
WD: fix .gitignore on .gradle build cache and Android build artefacts from chatbot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ npm-debug.log*
 .env
 .env.*
 .env.example
+
+# Android / Gradle build cache
+.gradle/
+**/build/
+local.properties


### PR DESCRIPTION
When pulling from master, some untracked binary files from the `artificial-intelligence/T1_2025/T1_2025_LLM_Chatbot` Android project to appear in git status, creating noise for developers working on unrelated areas.

### Changes: Update root `.gitignore` to exclude:
- .gradle/ — Gradle daemon build cache
- **/build/ — Android build output
- local.properties — machine-specific Android SDK path

### Result
- Confirmed binary files in `artificial-intelligence/` no longer appears as untracked after applying the rules.