### PR TITLE
WD: remove dead /api/chat stub (non-functional, unuse, chatbot uses /api/search-use-cases)

### DIFF
--- a/next_webapp/src/app/api/chat/route.ts
+++ b/next_webapp/src/app/api/chat/route.ts
@@ -1,9 +1,0 @@
-import { NextResponse } from "next/server";
-
-export async function POST(req: Request) {
-  const { message } = await req.json();
-
-}
-
-
-


### PR DESCRIPTION
Removes the dead /api/chat route  an empty, non-functional stub that nothing uses.

 Why

 It was broken anyway, the route handler had no return statement, so it would 500 at runtime if anything actually called it.
Nothing references it  a repo-wide search for /api/chat returned zero callers (no components, pages, hooks, tests, or config).
The real chatbot doesn't use it the working chatbot widget (`src/app/chatbot/`) runs on local intent-matching plus /api/search-use-cases. /api/chat played no part in it.

Changes

Deleted src/app/api/chat/route.ts and the now-empty src/app/api/chat/ folder.