### PR TITLE
WD: fix admin usecase category

### DIFF
--- a/next_webapp/src/app/[locale]/admin/use-cases/edit/[id]/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/use-cases/edit/[id]/page.tsx
@@ -65,7 +65,6 @@ export default function EditUseCasePage() {
 
         setTitle(uc.title || "");
         setDescription(uc.description || "");
-        setCategoryId(uc.category_id ? String(uc.category_id) : "");
 
         setExistingImgUrl(uc.cover_img || null);
         setImagePreview(uc.cover_img || null);
@@ -81,7 +80,20 @@ export default function EditUseCasePage() {
         }
 
         if (catJson.success) {
-          setCategories(catJson.data || []);
+          const cats = catJson.data || [];
+          setCategories(cats);
+
+          // Support match by legacy_id (Supabase) or id (Mongo).
+          const matched = uc.category
+            ? cats.find(
+                (c: any) =>
+                  String(c.id) === String(uc.category.id) ||
+                  String(c.id) === String(uc.category.legacy_id),
+              )
+            : null;
+          setCategoryId(matched ? String(matched.id) : "");
+        } else {
+          setCategoryId("");
         }
       })
       .catch((e) => setFetchError(e instanceof Error ? e.message : "Failed to load use case."))

--- a/next_webapp/src/app/[locale]/admin/use-cases/page.tsx
+++ b/next_webapp/src/app/[locale]/admin/use-cases/page.tsx
@@ -114,10 +114,10 @@ const [toast, setToast] = useState<{ message: string; type: "success" | "error" 
     }
   }
 
-  const categoryMap = Object.fromEntries(categories.map((c) => [c.id, c.category_name]));
+  // Use category name from use case object
   const displayData = usecases.map((u) => ({
     ...u,
-    category_name: categoryMap[u.category_id] ?? "—",
+    category_name: u.category?.category_name ?? "—",
   }));
 
   return (


### PR DESCRIPTION
### Issue found

Two admin use-cases pages still assumed the old flat `category_id` field on a use case. Category is an embedded ref `category: {id, legacy_id, category_name}` so both silently broke:

1. Edit page: category dropdown reset to "Select a category" on every open, even when one was already set — saving from that state would silently wipe it.
2. List page: Category column showed "—" for every row.

## Changes

1. `edit/[id]/page.tsx`: match the use case's category against the /api/categories dropdown options by either `legacy_id` (from Supabase-backed shape) or `id` (Mongo).
2. `use-cases/page.tsx`: read `category_name` directly off the embedded ref
